### PR TITLE
feat: integrate dofile parser with guard path audit

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -21,6 +21,9 @@ IS_SAVE = true
 [SECURITY]
 IS_GUARD = true
 ADO_INSTALL_ALLOWED_GITHUB_REPOSITORIES = []
+# When true, GuardValidator scans dofiles for data-loading commands and
+# rejects paths/URLs that violate the same rules as get_data_info.
+enable_data_command_path_guard = false
 
 [PROJECT]
 WORKING_DIR = ""

--- a/src/stata_mcp/api/get_data_info.py
+++ b/src/stata_mcp/api/get_data_info.py
@@ -5,122 +5,16 @@
 #
 # @Author : Sepine Tam
 # @Email  : sepinetam@gmail.com
-# @File   : get_data_info.py
+# @File   : api/get_data_info.py
 
-import ipaddress
 import json
 import logging
 from pathlib import Path
 from typing import List
-from urllib.parse import urlparse
 
 from ..data_info import get_data_handler
+from ..guard.data_path_auditor import DataPathAuditor
 from ._runtime import create_runtime_context
-
-LOCAL_ACCESS_DENIED = "Access denied: data file must be within the working directory."
-URL_DOMAIN_ACCESS_DENIED = "Access denied: URL domain is not in the allowlist."
-IP_URL_ACCESS_DENIED = "Access denied: IP-based URLs are not allowed."
-NON_HTTPS_URL_ACCESS_DENIED = "Access denied: only HTTPS URLs are allowed."
-URL_USERINFO_ACCESS_DENIED = "Access denied: URL userinfo is not allowed."
-
-
-def _is_url(data_path: str) -> bool:
-    parsed_url = urlparse(data_path)
-    return bool(parsed_url.scheme and parsed_url.netloc)
-
-
-def _is_ip_host(host: str) -> bool:
-    try:
-        ipaddress.ip_address(host)
-    except ValueError:
-        return False
-    return True
-
-
-def _is_allowed_domain(host: str, allowed_domains: tuple[str, ...]) -> bool:
-    normalized_host = host.rstrip(".").lower()
-    for allowed_domain in allowed_domains:
-        normalized_allowed = allowed_domain.strip().rstrip(".").lower()
-        if not normalized_allowed:
-            continue
-        if normalized_host == normalized_allowed:
-            return True
-        if normalized_host.endswith(f".{normalized_allowed}"):
-            return True
-    return False
-
-
-def _safe_url_for_log(data_path: str) -> str:
-    parsed_url = urlparse(data_path)
-    safe_url = parsed_url._replace(query="", fragment="")
-    return safe_url.geturl()
-
-
-def _log_url_security_violation(data_path: str, host: str | None, reason: str) -> None:
-    logging.warning(
-        "[SECURITY VIOLATION] Attempted to access data URL outside allowlist: "
-        f"requested_url='{_safe_url_for_log(data_path)}', "
-        f"host='{host}', "
-        f"reason='{reason}'"
-    )
-
-
-def _validate_local_path(
-    data_path: str,
-    working_dir: Path,
-    *,
-    enforce_boundary: bool,
-) -> Path | str:
-    candidate_path = Path(data_path).expanduser()
-    if not enforce_boundary:
-        return candidate_path.resolve()
-
-    if not candidate_path.is_absolute():
-        candidate_path = working_dir / candidate_path
-    resolved_data_path = candidate_path.resolve()
-    resolved_working_dir = working_dir.resolve()
-    try:
-        resolved_data_path.relative_to(resolved_working_dir)
-    except ValueError:
-        logging.warning(
-            "[SECURITY VIOLATION] Attempted to access data file outside working directory: "
-            f"requested_path='{data_path}', "
-            f"resolved_path='{resolved_data_path}', "
-            f"working_dir='{resolved_working_dir.as_posix()}'"
-        )
-        return LOCAL_ACCESS_DENIED
-    return resolved_data_path
-
-
-def _validate_url(data_path: str, runtime_config) -> tuple[str, str] | str:
-    parsed_url = urlparse(data_path)
-    host = parsed_url.hostname
-    data_extension = Path(parsed_url.path).suffix.lower().strip(".")
-    if not runtime_config.ENABLE_DATA_INFO_URL_GUARD:
-        return data_path, data_extension
-
-    if parsed_url.scheme.lower() != "https":
-        _log_url_security_violation(data_path, host, "non-https-scheme")
-        return NON_HTTPS_URL_ACCESS_DENIED
-    if parsed_url.username or parsed_url.password:
-        _log_url_security_violation(data_path, host, "url-userinfo-not-allowed")
-        return URL_USERINFO_ACCESS_DENIED
-
-    if not host:
-        _log_url_security_violation(data_path, host, "domain-not-in-allowlist")
-        return URL_DOMAIN_ACCESS_DENIED
-    if _is_ip_host(host):
-        _log_url_security_violation(data_path, host, "ip-host-not-allowed")
-        return IP_URL_ACCESS_DENIED
-
-    if runtime_config.ENABLE_DATA_INFO_URL_GUARD and not _is_allowed_domain(
-        host,
-        runtime_config.DATA_INFO_ALLOWED_URL_DOMAINS,
-    ):
-        _log_url_security_violation(data_path, host, "domain-not-in-allowlist")
-        return URL_DOMAIN_ACCESS_DENIED
-
-    return data_path, data_extension
 
 
 def _get_data_info_impl(
@@ -133,18 +27,20 @@ def _get_data_info_impl(
 ) -> str:
     """Return descriptive statistics for a supported dataset."""
     runtime = create_runtime_context(config_file=config_file)
+    auditor = DataPathAuditor(
+        working_dir=runtime.config.WORKING_DIR,
+        strict_local_boundary=runtime.config.STRICT_DATA_INFO_LOCAL_BOUNDARY,
+        enable_url_guard=runtime.config.ENABLE_DATA_INFO_URL_GUARD,
+        allowed_url_domains=runtime.config.DATA_INFO_ALLOWED_URL_DOMAINS,
+    )
 
-    if _is_url(data_path):
-        validated_data = _validate_url(data_path, runtime.config)
+    if auditor.is_url(data_path):
+        validated_data = auditor.validate_url(data_path)
         if not isinstance(validated_data, tuple):
             return validated_data
         resolved_data_path, data_extension = validated_data
     else:
-        validated_data_path = _validate_local_path(
-            data_path,
-            runtime.config.WORKING_DIR,
-            enforce_boundary=runtime.config.STRICT_DATA_INFO_LOCAL_BOUNDARY,
-        )
+        validated_data_path = auditor.validate_local_path(data_path)
         if isinstance(validated_data_path, str):
             return validated_data_path
         resolved_data_path = validated_data_path
@@ -167,7 +63,7 @@ def _get_data_info_impl(
     except Exception as error:
         logging.error(
             "Failed to serialize data summary for %s: %s",
-            _safe_url_for_log(str(resolved_data_path)),
+            DataPathAuditor._safe_url_for_log(str(resolved_data_path)),
             error,
         )
         return f"Failed to generate data summary for {resolved_data_path}: {error}"

--- a/src/stata_mcp/api/stata_do.py
+++ b/src/stata_mcp/api/stata_do.py
@@ -74,7 +74,9 @@ def _stata_do(
         if not resolved_dofile_path.exists():
             return {"error": f"Dofile {resolved_dofile_path} does not exist"}
     except Exception as error:
-        return {"error": f"Could not recognize dofile_path as pathlib.Path object: {error}"}
+        return {
+            "error": f"Could not recognize dofile_path as pathlib.Path object: {error}"
+        }
 
     resolved_dofile_path = resolved_dofile_path.resolve()
     candidate_allowed_dirs = [
@@ -87,30 +89,24 @@ def _stata_do(
             allowed_dirs.append(candidate_dir.resolve())
         else:
             logging.warning(
-                "Skip missing allowed directory for dofile execution boundary check: "
-                f"{candidate_dir}"
+                "Skip missing allowed directory for dofile execution boundary check."
             )
 
     if not _is_within_allowed_directories(resolved_dofile_path, allowed_dirs):
         logging.warning(
-            f"[SECURITY VIOLATION] Attempted to execute dofile outside allowed directories: "
-            f"requested_path='{dofile_path}', "
-            f"resolved_path='{resolved_dofile_path}', "
-            f"allowed_directories='{[allowed_dir.as_posix() for allowed_dir in allowed_dirs]}'"
+            "[SECURITY VIOLATION] Attempted to execute dofile outside allowed directories."
         )
         return {
-            "error": f"Access denied: Dofile '{resolved_dofile_path}' is outside allowed directories.",
-            "allowed_directories": [allowed_dir.as_posix() for allowed_dir in allowed_dirs],
+            "error": "Access denied: Dofile is outside allowed directories.",
+            "allowed_directories": [
+                allowed_dir.as_posix() for allowed_dir in allowed_dirs
+            ],
         }
 
     try:
         dofile_content = resolved_dofile_path.read_text(encoding="utf-8")
     except Exception as error:
-        logging.error(
-            "Failed to read dofile %s for security check: %s",
-            resolved_dofile_path,
-            error,
-        )
+        logging.error("Failed to read dofile for security check.")
         return {"error": f"Failed to read dofile for security check: {error}"}
 
     if not allow_package_management:
@@ -119,11 +115,13 @@ def _stata_do(
             return _security_rejection(package_report, resolved_dofile_path)
 
     if runtime.config.IS_GUARD:
-        report = GuardValidator().validate(dofile_content)
+        report = GuardValidator().validate(dofile_content, config=runtime.config)
         if not report.is_safe:
             return _security_rejection(report, resolved_dofile_path)
     else:
-        logging.warning("[SECURITY] Guard is disabled. Dangerous dofile commands will not be blocked.")
+        logging.warning(
+            "[SECURITY] Guard is disabled. Dangerous dofile commands will not be blocked."
+        )
 
     monitors = []
     if runtime.config.IS_MONITOR and runtime.config.MAX_RAM_MB is not None:
@@ -162,13 +160,13 @@ def _stata_do(
     except RAMLimitExceededError as error:
         return {"error": f"Out of max RAM limit: {error}"}
     except Exception as error:
-        logging.error("Failed to execute %s: %s", resolved_dofile_path, error)
+        logging.error("Failed to execute dofile.")
+        logging.debug("Execution exception details: %s", error)
         return {"error": str(error)}
 
     result: Dict[str, Any] = {
         "log_file_path": {
-            key: value.as_posix()
-            for key, value in log_file_path_mapping.items()
+            key: value.as_posix() for key, value in log_file_path_mapping.items()
         }
     }
 
@@ -207,8 +205,7 @@ def _security_rejection(report, resolved_dofile_path: Path) -> Dict[str, Any]:
         f"line {item.line}:{item.type}" for item in report.dangerous_items
     )
     logging.warning(
-        "[SECURITY VIOLATION] Security rejection for %s: %s",
-        resolved_dofile_path,
+        "[SECURITY VIOLATION] Security rejection for dofile: %s",
         dangerous_summary,
     )
     warning_message = "⚠️  Security warning: Dangerous commands detected:\n"

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -75,14 +75,18 @@ class Config:
         env_config_file = self._clean_string_value(os.getenv(self.ENV_CONFIG_FILE))
         debug_config_file = config_file if config_file is not None else env_config_file
         self.is_debug_config = debug_config_file is not None
-        self.system_config_file = self.SYSTEM_CONFIG_FILE if platform.system() == "Linux" else None
+        self.system_config_file = (
+            self.SYSTEM_CONFIG_FILE if platform.system() == "Linux" else None
+        )
 
         if debug_config_file is not None:
             self.config_file = Path(debug_config_file).expanduser()
             self.user_config_file = self.config_file
             self.project_config_file = None
             self.config_files = tuple(
-                path for path in (self.config_file, self.system_config_file) if path is not None
+                path
+                for path in (self.config_file, self.system_config_file)
+                if path is not None
             )
         else:
             self.user_config_file = self.STATA_MCP_DIRECTORY / self.USER_CONFIG_NAME
@@ -90,7 +94,11 @@ class Config:
             self.config_file = self.user_config_file
             self.config_files = tuple(
                 path
-                for path in (self.user_config_file, self.project_config_file, self.system_config_file)
+                for path in (
+                    self.user_config_file,
+                    self.project_config_file,
+                    self.system_config_file,
+                )
                 if path is not None
             )
 
@@ -131,7 +139,9 @@ class Config:
             project_security = project_config.get(cls.SECURITY_SECTION, {})
             if not isinstance(project_security, dict):
                 project_security = {}
-            merged[cls.SECURITY_SECTION] = cls._deep_merge(project_security, user_security)
+            merged[cls.SECURITY_SECTION] = cls._deep_merge(
+                project_security, user_security
+            )
         return cls._deep_merge(merged, system_config)
 
     @classmethod
@@ -167,7 +177,9 @@ class Config:
             return ""
         return config_file.read_text(encoding="utf-8")
 
-    def _get_raw_config_value(self, config_data: dict[str, Any], config_keys: list) -> Any | None:
+    def _get_raw_config_value(
+        self, config_data: dict[str, Any], config_keys: list
+    ) -> Any | None:
         config_dict = config_data
         for key in config_keys[:-1]:
             config_dict = config_dict.get(key, {})
@@ -244,7 +256,9 @@ class Config:
 
         updated[section][key] = cleaned_value
         self._write_toml(updated)
-        logger.info("Updated config %s = %s in %s", dot_key, cleaned_value, self.config_file)
+        logger.info(
+            "Updated config %s = %s in %s", dot_key, cleaned_value, self.config_file
+        )
 
     @staticmethod
     def _clean_string_value(value):
@@ -263,7 +277,9 @@ class Config:
             value = None
         return value
 
-    def _get_config_value(self, config_keys: list, env_var: str, default, converter=None, validator=None):
+    def _get_config_value(
+        self, config_keys: list, env_var: str, default, converter=None, validator=None
+    ):
         """
         Generic configuration reading method with priority: environment variable > toml config file > default value
 
@@ -386,7 +402,7 @@ class Config:
             env_var="STATA_MCP__IS_DEBUG",
             default=False,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -396,7 +412,7 @@ class Config:
             env_var="STATA_MCP__IS_ASYNC_DO",
             default=False,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -406,7 +422,7 @@ class Config:
             env_var="STATA_MCP__MAX_ASYNC_DO",
             default=3,
             converter=self._to_int,
-            validator=lambda x: isinstance(x, int) and x > 0
+            validator=lambda x: isinstance(x, int) and x > 0,
         )
 
     @property
@@ -416,7 +432,7 @@ class Config:
             env_var="STATA_MCP__CACHE_HELP",
             default=True,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -426,7 +442,7 @@ class Config:
             env_var="STATA_MCP__SAVE_HELP",
             default=True,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -436,7 +452,7 @@ class Config:
             env_var="STATA_MCP__LOGGING_ON",
             default=True,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -446,7 +462,7 @@ class Config:
             env_var="STATA_MCP__LOGGING_CONSOLE_HANDLER_ON",
             default=False,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -456,7 +472,7 @@ class Config:
             env_var="STATA_MCP__LOGGING_FILE_HANDLER_ON",
             default=True,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -466,7 +482,7 @@ class Config:
             env_var="STATA_MCP__LOG_FILE",
             default=self.STATA_MCP_DIRECTORY / "stata_mcp_debug.log",
             converter=self._to_path,
-            validator=lambda x: isinstance(x, Path)
+            validator=lambda x: isinstance(x, Path),
         )
 
         log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -479,7 +495,7 @@ class Config:
             env_var="STATA_MCP__LOGGING__MAX_BYTES",
             default=10_000_000,
             converter=self._to_int,
-            validator=lambda x: isinstance(x, int) and x > 0
+            validator=lambda x: isinstance(x, int) and x > 0,
         )
 
     @property
@@ -489,7 +505,7 @@ class Config:
             env_var="STATA_MCP__LOGGING__BACKUP_COUNT",
             default=5,
             converter=self._to_int,
-            validator=lambda x: isinstance(x, int) and x >= 0
+            validator=lambda x: isinstance(x, int) and x >= 0,
         )
 
     @property
@@ -528,7 +544,7 @@ class Config:
             env_var="STATA_MCP__IS_GUARD",
             default=True,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @cached_property
@@ -562,6 +578,16 @@ class Config:
             validator=lambda x: isinstance(x, tuple),
         )
 
+    @cached_property
+    def ENABLE_DATA_COMMAND_PATH_GUARD(self) -> bool:
+        return self._get_config_value(
+            config_keys=["SECURITY", "enable_data_command_path_guard"],
+            env_var="STATA_MCP__ENABLE_DATA_COMMAND_PATH_GUARD",
+            default=False,
+            converter=self._to_bool,
+            validator=lambda x: isinstance(x, bool),
+        )
+
     @property
     def IS_MONITOR(self) -> bool:
         return self._get_config_value(
@@ -569,7 +595,7 @@ class Config:
             env_var="STATA_MCP__IS_MONITOR",
             default=False,
             converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool)
+            validator=lambda x: isinstance(x, bool),
         )
 
     @property
@@ -606,8 +632,8 @@ class Config:
             return
 
         migrate_message = (
-            "Warning! Stata MCP has migrated from \"$PWD / stata-mcp-folder\" "
-            "to \"$PWD / .statamcp\" since v1.16.0. "
+            'Warning! Stata MCP has migrated from "$PWD / stata-mcp-folder" '
+            'to "$PWD / .statamcp" since v1.16.0. '
             "To keep using the old folder, set environment variable "
             "STATA_MCP__FOLDER_TAG=stata-mcp-folder."
         )
@@ -632,7 +658,7 @@ class Config:
             env_var="STATA_MCP__FOLDER_TAG",
             default=".statamcp",
             converter=self._to_str,
-            validator=lambda x: isinstance(x, str)
+            validator=lambda x: isinstance(x, str),
         )
 
     @cached_property
@@ -674,7 +700,7 @@ class Config:
             env_var="STATA_MCP__RAM_LIMIT",
             default=-1,
             converter=self._to_int,
-            validator=lambda x: isinstance(x, int)
+            validator=lambda x: isinstance(x, int),
         )
 
         # Convert -1 to None (no limit)

--- a/src/stata_mcp/guard/__init__.py
+++ b/src/stata_mcp/guard/__init__.py
@@ -20,6 +20,7 @@ Usage:
     ...     print(f"Dangerous items found: {report.dangerous_items}")
 """
 
+from .data_path_auditor import DataPathAuditor
 from .input_validation import (
     require_ado_install_confirmation,
     validate_ado_install_request,
@@ -37,6 +38,7 @@ from .validator import (
 )
 
 __all__ = [
+    "DataPathAuditor",
     "GuardValidator",
     "PackageManagementGuardValidator",
     "RiskItem",

--- a/src/stata_mcp/guard/data_path_auditor.py
+++ b/src/stata_mcp/guard/data_path_auditor.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 - Present Sepine Tam, Inc. All Rights Reserved
+#
+# @Author : Sepine Tam (谭淞)
+# @Email  : sepinetam@gmail.com
+# @File   : guard/data_path_auditor.py
+
+"""Shared data path/URL security auditor."""
+
+import ipaddress
+import logging
+from pathlib import Path
+from urllib.parse import urlparse
+
+LOCAL_ACCESS_DENIED = "Access denied: data file must be within the working directory."
+URL_DOMAIN_ACCESS_DENIED = "Access denied: URL domain is not in the allowlist."
+IP_URL_ACCESS_DENIED = "Access denied: IP-based URLs are not allowed."
+NON_HTTPS_URL_ACCESS_DENIED = "Access denied: only HTTPS URLs are allowed."
+URL_USERINFO_ACCESS_DENIED = "Access denied: URL userinfo is not allowed."
+
+
+class DataPathAuditor:
+    """Validate data file paths and URLs against security policy.
+
+    This class centralizes the boundary and URL guard logic used by
+    ``get_data_info`` and ``GuardValidator`` so both paths enforce the
+    same rules.
+    """
+
+    def __init__(
+        self,
+        working_dir: Path,
+        strict_local_boundary: bool,
+        enable_url_guard: bool,
+        allowed_url_domains: tuple[str, ...],
+    ) -> None:
+        """Initialize the auditor.
+
+        Args:
+            working_dir: Base directory for relative local paths.
+            strict_local_boundary: When True, reject local paths outside
+                ``working_dir``.
+            enable_url_guard: When True, enforce HTTPS, host, and allowlist
+                restrictions on URLs.
+            allowed_url_domains: Domains permitted when URL guard is enabled.
+        """
+        self.working_dir = working_dir
+        self.strict_local_boundary = strict_local_boundary
+        self.enable_url_guard = enable_url_guard
+        self.allowed_url_domains = allowed_url_domains
+
+    @staticmethod
+    def is_url(data_path: str) -> bool:
+        """Return True when ``data_path`` looks like a URL."""
+        parsed_url = urlparse(data_path)
+        return bool(parsed_url.scheme and parsed_url.netloc)
+
+    @staticmethod
+    def _is_ip_host(host: str) -> bool:
+        """Return True when ``host`` is an IP address literal."""
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            return False
+        return True
+
+    @staticmethod
+    def _is_allowed_domain(host: str, allowed_domains: tuple[str, ...]) -> bool:
+        """Return True when ``host`` matches an allowed domain."""
+        normalized_host = host.rstrip(".").lower()
+        for allowed_domain in allowed_domains:
+            normalized_allowed = allowed_domain.strip().rstrip(".").lower()
+            if not normalized_allowed:
+                continue
+            if normalized_host == normalized_allowed:
+                return True
+            if normalized_host.endswith(f".{normalized_allowed}"):
+                return True
+        return False
+
+    @staticmethod
+    def _safe_url_for_log(data_path: str) -> str:
+        """Return ``data_path`` with userinfo, query, and fragment redacted."""
+        parsed_url = urlparse(data_path)
+        safe_url = parsed_url._replace(
+            netloc=parsed_url.hostname or "",
+            query="",
+            fragment="",
+        )
+        return safe_url.geturl()
+
+    @classmethod
+    def _log_url_security_violation(
+        cls,
+        data_path: str,
+        host: str | None,
+        reason: str,
+    ) -> None:
+        """Log a URL guard rejection."""
+        logging.warning(
+            "[SECURITY VIOLATION] Attempted to access data URL outside allowlist: "
+            f"requested_url='{cls._safe_url_for_log(data_path)}', "
+            f"host='{host}', "
+            f"reason='{reason}'"
+        )
+
+    def validate_local_path(self, data_path: str) -> Path | str:
+        """Validate a local file path.
+
+        Returns the resolved ``Path`` when allowed, or an access-denied
+        message string when rejected.
+        """
+        candidate_path = Path(data_path).expanduser()
+        if not self.strict_local_boundary:
+            return candidate_path.resolve()
+
+        if not candidate_path.is_absolute():
+            candidate_path = self.working_dir / candidate_path
+        resolved_data_path = candidate_path.resolve()
+        resolved_working_dir = self.working_dir.resolve()
+        try:
+            resolved_data_path.relative_to(resolved_working_dir)
+        except ValueError:
+            logging.warning(
+                "[SECURITY VIOLATION] Attempted to access data file outside working directory."
+            )
+            return LOCAL_ACCESS_DENIED
+        return resolved_data_path
+
+    def validate_url(self, data_path: str) -> tuple[str, str] | str:
+        """Validate a URL.
+
+        Returns a ``(url, extension)`` tuple when allowed, or an
+        access-denied message string when rejected.
+        """
+        parsed_url = urlparse(data_path)
+        host = parsed_url.hostname
+        data_extension = Path(parsed_url.path).suffix.lower().strip(".")
+        if not self.enable_url_guard:
+            return data_path, data_extension
+
+        if parsed_url.scheme.lower() != "https":
+            self._log_url_security_violation(data_path, host, "non-https-scheme")
+            return NON_HTTPS_URL_ACCESS_DENIED
+        if parsed_url.username or parsed_url.password:
+            self._log_url_security_violation(
+                data_path, host, "url-userinfo-not-allowed"
+            )
+            return URL_USERINFO_ACCESS_DENIED
+
+        if not host:
+            self._log_url_security_violation(data_path, host, "domain-not-in-allowlist")
+            return URL_DOMAIN_ACCESS_DENIED
+        if self._is_ip_host(host):
+            self._log_url_security_violation(data_path, host, "ip-host-not-allowed")
+            return IP_URL_ACCESS_DENIED
+
+        if not self._is_allowed_domain(host, self.allowed_url_domains):
+            self._log_url_security_violation(data_path, host, "domain-not-in-allowlist")
+            return URL_DOMAIN_ACCESS_DENIED
+
+        return data_path, data_extension
+
+
+__all__ = [
+    "DataPathAuditor",
+    "LOCAL_ACCESS_DENIED",
+    "URL_DOMAIN_ACCESS_DENIED",
+    "IP_URL_ACCESS_DENIED",
+    "NON_HTTPS_URL_ACCESS_DENIED",
+    "URL_USERINFO_ACCESS_DENIED",
+]

--- a/src/stata_mcp/guard/validator.py
+++ b/src/stata_mcp/guard/validator.py
@@ -16,7 +16,7 @@ commands and patterns in Stata dofile code.
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, List
 
 from .blacklist import (
     DANGEROUS_COMMANDS,
@@ -24,8 +24,62 @@ from .blacklist import (
     PACKAGE_MANAGEMENT_COMMANDS,
     STATA_PREFIXES,
 )
+from .data_path_auditor import DataPathAuditor
+from ..utils.parse_dofile import (
+    ExpansionResult,
+    ParsedCommand,
+    expand_code_for_security,
+)
 
 logger = logging.getLogger(__name__)
+
+DIRECT_DATA_COMMANDS = {
+    "use",
+    "import",
+    "insheet",
+    "infile",
+    "infix",
+}
+USING_DATA_COMMANDS = {
+    "merge",
+    "merg",
+    "mer",
+    "append",
+    "appen",
+    "appe",
+    "app",
+    "ap",
+    "joinby",
+    "joinb",
+}
+CONTEXT_MUTATION_COMMANDS = {"cd", "chdir"}
+PATH_LIKE_COMMANDS = (
+    DIRECT_DATA_COMMANDS
+    | USING_DATA_COMMANDS
+    | {
+        "save",
+        "saveold",
+        "sysuse",
+        "webuse",
+        "export",
+        "outfile",
+        "outsheet",
+        "do",
+        "run",
+        "include",
+        "type",
+        "erase",
+        "rmdir",
+        "mkdir",
+        "copy",
+    }
+)
+UNRESOLVED_MACRO_PATTERN = re.compile(
+    r"`[A-Za-z_][A-Za-z0-9_]*'|"
+    r"`[=:]|"
+    r"\$\{[A-Za-z_][A-Za-z0-9_]*\}|"
+    r"\$[A-Za-z_][A-Za-z0-9_]*"
+)
 
 # ============================================================================
 # Data Structures
@@ -37,7 +91,8 @@ class RiskItem:
     """Represents a single security risk item found in the code.
 
     Attributes:
-        type: The type of risk ("command" or "pattern")
+        type: The type of risk ("command", "pattern", "macro", "parse",
+            "context", or "data_path")
         content: The actual content that triggered the risk
         line: Line number where the risk was found (1-indexed)
     """
@@ -77,6 +132,7 @@ class SecurityReport:
 # ============================================================================
 # Core Validator
 # ============================================================================
+
 
 class GuardValidator:
     """Validator for Stata dofile security.
@@ -118,16 +174,16 @@ class GuardValidator:
         while cleaned_line:
             version_match = version_prefix_pattern.match(cleaned_line)
             if version_match:
-                cleaned_line = cleaned_line[version_match.end():]
+                cleaned_line = cleaned_line[version_match.end() :]
                 continue
             frame_match = frame_prefix_pattern.match(cleaned_line)
             if frame_match:
-                cleaned_line = cleaned_line[frame_match.end():]
+                cleaned_line = cleaned_line[frame_match.end() :]
                 continue
             matched = prefix_pattern.match(cleaned_line)
             if not matched or matched.group(1).lower() not in prefixes:
                 break
-            cleaned_line = cleaned_line[matched.end():]
+            cleaned_line = cleaned_line[matched.end() :]
         return cleaned_line.strip()
 
     @staticmethod
@@ -163,24 +219,74 @@ class GuardValidator:
 
         return executable_lines
 
-    def validate(self, code: str) -> SecurityReport:
+    def validate(self, code: str, config: Any | None = None) -> SecurityReport:
         """Validate Stata dofile code for security risks.
 
         Args:
             code: The Stata dofile code to validate
+            config: Optional runtime config. When provided and
+                ``ENABLE_DATA_COMMAND_PATH_GUARD`` is True, data-loading
+                commands are audited for path/URL boundary violations.
 
         Returns:
             SecurityReport containing validation results
         """
         dangerous_items: List[RiskItem] = []
 
-        # Split code into lines for line number tracking
-        lines = code.split("\n")
+        original_executable_lines = self._iter_executable_lines(code.split("\n"))
+        dangerous_local_names = self._collect_dangerous_local_names(
+            original_executable_lines
+        )
+        for line_num, line in original_executable_lines:
+            stripped_line = line.strip()
+            if (
+                not stripped_line
+                or stripped_line.startswith("*")
+                or stripped_line.startswith("//")
+            ):
+                continue
+            cleaned_line = self._strip_prefixes(stripped_line, self.stata_prefixes)
+            dangerous_items.extend(
+                self._check_macro_expansion(
+                    cleaned_line, line_num, dangerous_local_names
+                )
+            )
+            dangerous_items.extend(
+                self._check_dangerous_patterns(cleaned_line, line_num)
+            )
+
+        expansion_result = expand_code_for_security(code)
+        if expansion_result.requires_global_fail_closed:
+            for diagnostic in expansion_result.diagnostics:
+                if not diagnostic.security_relevant or diagnostic.scope != "global":
+                    continue
+                dangerous_items.append(
+                    RiskItem(
+                        type="parse",
+                        content=diagnostic.code,
+                        line=diagnostic.line,
+                    )
+                )
+
+        lines = expansion_result.expanded_code.split("\n")
         executable_lines = self._iter_executable_lines(lines)
 
-        dangerous_local_names = self._collect_dangerous_local_names(executable_lines)
+        data_path_auditor = None
+        if config is not None and getattr(
+            config, "ENABLE_DATA_COMMAND_PATH_GUARD", False
+        ):
+            data_path_auditor = DataPathAuditor(
+                working_dir=config.WORKING_DIR,
+                strict_local_boundary=config.STRICT_DATA_INFO_LOCAL_BOUNDARY,
+                enable_url_guard=config.ENABLE_DATA_INFO_URL_GUARD,
+                allowed_url_domains=config.DATA_INFO_ALLOWED_URL_DOMAINS,
+            )
 
         for line_num, line in executable_lines:
+            origin_line_num = self._origin_line_for_expanded_line(
+                line_num,
+                expansion_result.line_map,
+            )
             # Skip empty lines and comments
             stripped_line = line.strip()
             if (
@@ -190,25 +296,39 @@ class GuardValidator:
             ):
                 continue
 
-            if re.match(r"^#delimit\s+;", stripped_line, re.IGNORECASE):
-                dangerous_items.append(RiskItem(type="pattern", content="#delimit ;", line=line_num))
-                continue
-
             # Strip Stata prefixes (capture, quietly, etc.) before checking
             cleaned_line = self._strip_prefixes(stripped_line, self.stata_prefixes)
             if not cleaned_line:
                 continue
 
-            macro_items = self._check_macro_expansion(cleaned_line, line_num, dangerous_local_names)
-            dangerous_items.extend(macro_items)
-
             # Check for dangerous commands
-            command_items = self._check_dangerous_commands(cleaned_line, line_num)
+            command_items = self._check_dangerous_commands(
+                cleaned_line, origin_line_num
+            )
             dangerous_items.extend(command_items)
 
             # Check for dangerous patterns
-            pattern_items = self._check_dangerous_patterns(cleaned_line, line_num)
+            pattern_items = self._check_dangerous_patterns(
+                cleaned_line, origin_line_num
+            )
             dangerous_items.extend(pattern_items)
+
+        for command in expansion_result.commands:
+            dangerous_items.extend(
+                self._check_command_parse_diagnostics(
+                    command,
+                    expansion_result,
+                    data_path_guard_enabled=data_path_auditor is not None,
+                )
+            )
+
+        # Check data-loading command paths when the guard is enabled.
+        if data_path_auditor is not None:
+            for command in expansion_result.commands:
+                dangerous_items.extend(self._check_context_mutation_command(command))
+                dangerous_items.extend(
+                    self._check_data_command_path(command, data_path_auditor)
+                )
 
         # Generate report
         is_safe = len(dangerous_items) == 0
@@ -224,14 +344,31 @@ class GuardValidator:
             logger.debug("Guard validation passed with no dangerous items")
         return SecurityReport(is_safe=is_safe, dangerous_items=dangerous_items)
 
+    @staticmethod
+    def _origin_line_for_expanded_line(
+        expanded_line_num: int,
+        line_map: dict[int, list[int]],
+    ) -> int:
+        """Return the first original source line for an expanded line."""
+        origins = line_map.get(expanded_line_num)
+        if origins:
+            return origins[0]
+        return expanded_line_num
+
     def _collect_dangerous_local_names(self, lines: List[tuple[int, str]]) -> set[str]:
         """Collect macro names whose values are dangerous commands."""
         dangerous_names: set[str] = set()
-        macro_pattern = re.compile(r"^\s*(?:local|global)\s+(\w+)\s+(.+)$", re.IGNORECASE)
+        macro_pattern = re.compile(
+            r"^\s*(?:local|global)\s+(\w+)\s+(.+)$", re.IGNORECASE
+        )
 
         for _line_num, line in lines:
             stripped_line = line.strip()
-            if not stripped_line or stripped_line.startswith("*") or stripped_line.startswith("//"):
+            if (
+                not stripped_line
+                or stripped_line.startswith("*")
+                or stripped_line.startswith("//")
+            ):
                 continue
 
             cleaned_line = self._strip_prefixes(stripped_line, self.stata_prefixes)
@@ -239,7 +376,9 @@ class GuardValidator:
             if not matched:
                 continue
 
-            local_name, local_value = matched.group(1), self._strip_macro_value_quotes(matched.group(2))
+            local_name, local_value = matched.group(1), self._strip_macro_value_quotes(
+                matched.group(2)
+            )
             first_value_token = (
                 self._normalize_command_token(local_value.split()[0])
                 if local_value.split()
@@ -254,14 +393,24 @@ class GuardValidator:
     def _strip_macro_value_quotes(value: str) -> str:
         """Remove Stata macro value quotes, including compound quotes."""
         stripped_value = value.strip()
-        if len(stripped_value) >= 4 and stripped_value.startswith('`"') and stripped_value.endswith('"\''):
+        if (
+            len(stripped_value) >= 4
+            and stripped_value.startswith('`"')
+            and stripped_value.endswith("\"'")
+        ):
             return stripped_value[2:-2]
-        if len(stripped_value) >= 2 and stripped_value[0] == stripped_value[-1] and stripped_value[0] in {'"', "'"}:
+        if (
+            len(stripped_value) >= 2
+            and stripped_value[0] == stripped_value[-1]
+            and stripped_value[0] in {'"', "'"}
+        ):
             return stripped_value[1:-1]
         return stripped_value
 
     @staticmethod
-    def _check_macro_expansion(line: str, line_num: int, dangerous_local_names: set[str]) -> List[RiskItem]:
+    def _check_macro_expansion(
+        line: str, line_num: int, dangerous_local_names: set[str]
+    ) -> List[RiskItem]:
         """Check whether a line expands a dangerous macro."""
         items: List[RiskItem] = []
         for local_name in dangerous_local_names:
@@ -275,6 +424,70 @@ class GuardValidator:
                 macro_token = f"${local_name}"
                 items.append(RiskItem(type="macro", content=macro_token, line=line_num))
         return items
+
+    def _check_command_parse_diagnostics(
+        self,
+        command: ParsedCommand,
+        expansion_result: ExpansionResult,
+        data_path_guard_enabled: bool,
+    ) -> List[RiskItem]:
+        """Fail closed on line-scoped parser uncertainty for sensitive commands."""
+        diagnostics = [
+            diagnostic
+            for diagnostic in expansion_result.diagnostics_on(command)
+            if diagnostic.security_relevant and diagnostic.scope == "line"
+        ]
+        if not diagnostics:
+            return []
+
+        if not self._command_requires_line_fail_closed(
+            command,
+            data_path_guard_enabled=data_path_guard_enabled,
+        ):
+            return []
+
+        line_num = self._command_origin_line(command)
+        return [
+            RiskItem(
+                type="parse",
+                content=diagnostic.code,
+                line=diagnostic.line or line_num,
+            )
+            for diagnostic in diagnostics
+        ]
+
+    def _command_requires_line_fail_closed(
+        self,
+        command: ParsedCommand,
+        data_path_guard_enabled: bool,
+    ) -> bool:
+        """Return True when parser uncertainty on this command is security-sensitive."""
+        if UNRESOLVED_MACRO_PATTERN.search(command.name):
+            return True
+        if command.name in self.dangerous_commands:
+            return True
+        if command.text.startswith("!"):
+            return True
+        if data_path_guard_enabled and (
+            command.name in PATH_LIKE_COMMANDS
+            or command.name in CONTEXT_MUTATION_COMMANDS
+        ):
+            return True
+        return False
+
+    @staticmethod
+    def _check_context_mutation_command(command: ParsedCommand) -> List[RiskItem]:
+        """Reject commands that make later relative path auditing unreliable."""
+        if command.name not in CONTEXT_MUTATION_COMMANDS:
+            return []
+        line_num = GuardValidator._command_origin_line(command)
+        logger.warning(
+            "[SECURITY VIOLATION] Guard blocked context-mutating command: "
+            "command='%s', line=%d",
+            command.name,
+            line_num,
+        )
+        return [RiskItem(type="context", content=command.name, line=line_num)]
 
     def _check_dangerous_commands(self, line: str, line_num: int) -> List[RiskItem]:
         """Check if a line contains dangerous commands.
@@ -290,25 +503,15 @@ class GuardValidator:
 
         # Get the first word (command)
         first_word = (
-            self._normalize_command_token(line.split()[0])
-            if line.split()
-            else ""
+            self._normalize_command_token(line.split()[0]) if line.split() else ""
         )
 
         if first_word in self.dangerous_commands:
-            items.append(RiskItem(
-                type="command",
-                content=first_word,
-                line=line_num
-            ))
+            items.append(RiskItem(type="command", content=first_word, line=line_num))
 
         # Special check for "!" which is a prefix
         if line.startswith("!"):
-            items.append(RiskItem(
-                type="command",
-                content="!",
-                line=line_num
-            ))
+            items.append(RiskItem(type="command", content="!", line=line_num))
 
         return items
 
@@ -331,13 +534,106 @@ class GuardValidator:
 
         for pattern in self.dangerous_patterns:
             if re.search(pattern, line, re.IGNORECASE):
-                items.append(RiskItem(
-                    type="pattern",
-                    content=pattern,
-                    line=line_num
-                ))
+                items.append(RiskItem(type="pattern", content=pattern, line=line_num))
 
         return items
+
+    def _check_data_command_path(
+        self,
+        command: ParsedCommand,
+        data_path_auditor: DataPathAuditor,
+    ) -> List[RiskItem]:
+        """Check whether a data-loading command references a disallowed path or URL.
+
+        Covers direct loaders such as ``use`` and ``import <subcmd>`` as well
+        as ``merge`` / ``append`` / ``joinby ... using`` syntax.
+        """
+        line_num = self._command_origin_line(command)
+
+        if command.name == "webuse":
+            return self._check_webuse_command(command, data_path_auditor)
+
+        if command.name not in PATH_LIKE_COMMANDS:
+            return []
+
+        items: List[RiskItem] = []
+        for data_path in command.data_paths:
+            item = self._audit_data_path(data_path, line_num, data_path_auditor)
+            if item is not None:
+                items.append(item)
+
+        return items
+
+    def _check_webuse_command(
+        self,
+        command: ParsedCommand,
+        data_path_auditor: DataPathAuditor,
+    ) -> List[RiskItem]:
+        """Reject unauditable ``webuse`` loads and audit ``webuse set`` URLs."""
+        line_num = self._command_origin_line(command)
+        remainder = command.text[len("webuse") :]
+        normalized = remainder.strip()
+        if not normalized.lower().startswith("set"):
+            logger.warning(
+                "[SECURITY VIOLATION] Guard blocked webuse data load: line=%d",
+                line_num,
+            )
+            return [RiskItem(type="data_path", content="webuse", line=line_num)]
+
+        data_paths = list(command.data_paths)
+        if not data_paths:
+            return [RiskItem(type="data_path", content="webuse set", line=line_num)]
+
+        items: List[RiskItem] = []
+        for data_path in data_paths:
+            item = self._audit_data_path(data_path, line_num, data_path_auditor)
+            if item is not None:
+                items.append(item)
+        return items
+
+    @staticmethod
+    def _command_origin_line(command: ParsedCommand) -> int:
+        """Return the first original source line for a parsed command."""
+        if command.origins:
+            return command.origins[0]
+        return command.line
+
+    @staticmethod
+    def _audit_data_path(
+        data_path: str,
+        line_num: int,
+        data_path_auditor: DataPathAuditor,
+    ) -> RiskItem | None:
+        """Return a risk item when ``data_path`` violates the configured policy."""
+        if UNRESOLVED_MACRO_PATTERN.search(data_path):
+            logger.warning(
+                "[SECURITY VIOLATION] Guard blocked data command with unresolved macro: "
+                "line=%d",
+                line_num,
+            )
+            return RiskItem(type="data_path", content=data_path, line=line_num)
+
+        if data_path_auditor.is_url(data_path):
+            result = data_path_auditor.validate_url(data_path)
+            if isinstance(result, str):
+                logger.warning(
+                    "[SECURITY VIOLATION] Guard blocked data command with disallowed URL: "
+                    "requested_url='%s', line=%d",
+                    data_path_auditor._safe_url_for_log(data_path),
+                    line_num,
+                )
+                return RiskItem(type="data_path", content=data_path, line=line_num)
+            return None
+
+        result = data_path_auditor.validate_local_path(data_path)
+        if isinstance(result, str):
+            logger.warning(
+                "[SECURITY VIOLATION] Guard blocked data command with disallowed local path: "
+                "line=%d",
+                line_num,
+            )
+            return RiskItem(type="data_path", content=data_path, line=line_num)
+        return None
 
 
 class PackageManagementGuardValidator(GuardValidator):

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -22,7 +22,9 @@ from .config import Config
 
 # Init project config
 config = Config()
-_ASYNC_DO_SEMAPHORES: weakref.WeakKeyDictionary[Any, tuple[int, asyncio.Semaphore]] = weakref.WeakKeyDictionary()
+_ASYNC_DO_SEMAPHORES: weakref.WeakKeyDictionary[Any, tuple[int, asyncio.Semaphore]] = (
+    weakref.WeakKeyDictionary()
+)
 
 # Maybe somebody does not like logging.
 # Whatever, left a controller switch `logging STATA_MCP_LOGGING_ON`. Turn off all logging with setting it as false.
@@ -48,24 +50,22 @@ if config.LOGGING_ON:
             stata_mcp_dot_log_file_path,
             maxBytes=config.MAX_BYTES,  # 10MB
             backupCount=config.BACKUP_COUNT,
-            encoding='utf-8'
+            encoding="utf-8",
         )
-        file_handler.setLevel(
-            logging.DEBUG if config.IS_DEBUG else logging.INFO
-        )
+        file_handler.setLevel(logging.DEBUG if config.IS_DEBUG else logging.INFO)
 
         logging_handlers.append(file_handler)
 
     logging.basicConfig(
         level=logging.DEBUG,
-        format='%(asctime)s - %(levelname)s - %(message)s',
-        handlers=logging_handlers
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=logging_handlers,
     )
 else:
     # Disable all logging by setting level above CRITICAL
     logging.disable(logging.CRITICAL + 1)
 
-logging.info(f"Using {config.WORKING_DIR.as_posix()} as working directory")
+logging.info("Working directory configured.")
 
 # Initialize MCP Server, avoiding FastMCP server timeout caused by Icon src fetch
 instructions = (
@@ -78,11 +78,13 @@ try:
         name="stata-mcp",
         instructions=instructions,
         website_url="https://www.statamcp.com",
-        icons=[Icon(
-            src="https://r2.statamcp.com/android-chrome-512x512.png",
-            mimeType="image/png",
-            sizes=["512x512"]
-        )]
+        icons=[
+            Icon(
+                src="https://r2.statamcp.com/android-chrome-512x512.png",
+                mimeType="image/png",
+                sizes=["512x512"],
+            )
+        ],
     )
 except Exception:
     stata_mcp = FastMCP(
@@ -163,16 +165,12 @@ def _prepare_stata_do_request(dofile_path: str) -> Dict[str, Any] | _StataDoRequ
             allowed_dirs.append(candidate_dir.resolve())
         else:
             logging.warning(
-                "Skip missing allowed directory for dofile execution boundary check: "
-                f"{candidate_dir}"
+                "Skip missing allowed directory for dofile execution boundary check."
             )
     is_allowed = _is_within_allowed_directories(dofile_path_resolved, allowed_dirs)
     if not is_allowed:
         logging.warning(
-            f"[SECURITY VIOLATION] Attempted to execute dofile outside allowed directories: "
-            f"requested_path='{dofile_path}', "
-            f"resolved_path='{dofile_path_resolved}', "
-            f"allowed_directories='{[d.as_posix() for d in allowed_dirs]}'"
+            "[SECURITY VIOLATION] Attempted to execute dofile outside allowed directories."
         )
         return {
             "error": f"Access denied: Dofile '{dofile_path}' is outside allowed directories.",
@@ -180,10 +178,10 @@ def _prepare_stata_do_request(dofile_path: str) -> Dict[str, Any] | _StataDoRequ
         }
 
     try:
-        with open(dofile_path, 'r', encoding='utf-8') as f:
+        with open(dofile_path, "r", encoding="utf-8") as f:
             dofile_content = f.read()
     except Exception as e:
-        logging.error(f"Failed to read dofile {dofile_path}: {str(e)}")
+        logging.error("Failed to read dofile for security check.")
         return {"error": f"Failed to read dofile for security check: {str(e)}"}
 
     from .guard import PackageManagementGuardValidator
@@ -207,34 +205,45 @@ def _prepare_stata_do_request(dofile_path: str) -> Dict[str, Any] | _StataDoRequ
         from .guard import GuardValidator
 
         # Config guard validator (platform-independent)
-        guard_validator = GuardValidator()  # TODO: It may be make an error for windows user
+        guard_validator = (
+            GuardValidator()
+        )  # TODO: It may be make an error for windows user
 
         # Perform security validation
-        report = guard_validator.validate(dofile_content)
+        report = guard_validator.validate(dofile_content, config=config)
 
         if not report.is_safe:
+            dangerous_summary = ", ".join(
+                f"line {item.line}:{item.type}" for item in report.dangerous_items
+            )
+            logging.warning(
+                "[SECURITY VIOLATION] Security rejection for dofile: %s",
+                dangerous_summary,
+            )
             warning_msg = "⚠️  Security warning: Dangerous commands detected:\n"
             for item in report.dangerous_items:
                 warning_msg += f"  - Line {item.line}: {item.type} '{item.content}'\n"
-            logging.warning(warning_msg)
             return {
                 "action": "Security check, dofile not executed",
                 "warning": warning_msg,
                 "suggesting": (
                     "Modify the dofile to ensure safety\n"
                     "or set environment variable `STATA_MCP__IS_GUARD` to `false` (not recommended)"
-                )
+                ),
             }
         else:
-            logging.info(f"✅ {dofile_path} - Security check passed")
+            logging.info("Security check passed for dofile.")
     else:
-        logging.warning("[SECURITY] Guard is disabled. Dangerous dofile commands will not be blocked.")
+        logging.warning(
+            "[SECURITY] Guard is disabled. Dangerous dofile commands will not be blocked."
+        )
 
     # Initialize monitors
     monitors = []
     if config.IS_MONITOR:
         if config.MAX_RAM_MB is not None:
             from .monitor import RAMMonitor
+
             monitors.append(RAMMonitor(max_ram_mb=config.MAX_RAM_MB))
 
     return _StataDoRequest(dofile_path=dofile_path, monitors=monitors)
@@ -289,12 +298,12 @@ def _get_async_do_semaphore() -> asyncio.Semaphore:
 
 
 def _sync_stata_do(
-        dofile_path: str,
-        log_file_name: str = None,
-        read_log_when_error: bool = False,
-        is_replace_log: bool = True,
-        enable_smcl: bool = True,
-        timeout: float | None = None,
+    dofile_path: str,
+    log_file_name: str = None,
+    read_log_when_error: bool = False,
+    is_replace_log: bool = True,
+    enable_smcl: bool = True,
+    timeout: float | None = None,
 ) -> Dict[str, Any]:
     """
     Execute a Stata do-file and return log file paths.
@@ -333,16 +342,17 @@ def _sync_stata_do(
 
     # Initialize Stata executor with system configuration
     from .stata import StataDo
+
     stata_executor = StataDo(
         stata_cli=config.STATA_CLI,  # Path to Stata executable
         log_file_path=config.STATA_MCP_FOLDER.LOG,  # Directory for log files
         is_unix=config.IS_UNIX,  # Whether the OS is Unix-like
         cwd=config.WORKING_DIR,
-        monitors=request.monitors
+        monitors=request.monitors,
     )
 
     # Execute the do-file and get log file path
-    logging.info(f"Try to running file {request.dofile_path}")
+    logging.info("Try to running dofile.")
 
     from .core.types import RAMLimitExceededError
 
@@ -355,12 +365,13 @@ def _sync_stata_do(
             timeout=timeout,
         )
         text_log = log_file_path_mapping.get("text").as_posix()
-        logging.info(f"{request.dofile_path} is executed successfully. Log file path: {text_log}")
+        logging.info("Dofile executed successfully.")
     except RAMLimitExceededError as e:
-        logging.error(f"Out of max RAM limit: {e}")
+        logging.error("Out of max RAM limit: %s", e)
         return {"error": f"Out of max RAM limit: {e}"}
     except Exception as e:
-        logging.error(f"Failed to execute {request.dofile_path}. Error: {str(e)}")
+        logging.error("Failed to execute dofile.")
+        logging.debug("Execution exception details: %s", e)
         return {"error": str(e)}
 
     return _format_stata_do_result(
@@ -373,12 +384,12 @@ def _sync_stata_do(
 
 
 async def _async_stata_do(
-        dofile_path: str,
-        log_file_name: str = None,
-        read_log_when_error: bool = False,
-        is_replace_log: bool = True,
-        enable_smcl: bool = True,
-        timeout: float | None = None,
+    dofile_path: str,
+    log_file_name: str = None,
+    read_log_when_error: bool = False,
+    is_replace_log: bool = True,
+    enable_smcl: bool = True,
+    timeout: float | None = None,
 ) -> Dict[str, Any]:
     """Async Stata do-file tool implementation."""
     request = _prepare_stata_do_request(dofile_path)
@@ -386,34 +397,38 @@ async def _async_stata_do(
         return request
 
     from .stata.stata_do.async_do import AsyncStataDo
+
     stata_executor = AsyncStataDo(
         stata_cli=config.STATA_CLI,
         log_file_path=config.STATA_MCP_FOLDER.LOG,
         is_unix=config.IS_UNIX,
         cwd=config.WORKING_DIR,
-        monitors=request.monitors
+        monitors=request.monitors,
     )
 
-    logging.info(f"Try to running file {request.dofile_path}")
+    logging.info("Try to running dofile.")
 
     from .core.types import RAMLimitExceededError
 
     try:
         async with _get_async_do_semaphore():
-            log_file_path_mapping: Dict[str, Path] = await stata_executor.execute_dofile_async(
-                request.dofile_path,
-                log_file_name,
-                is_replace_log,
-                enable_smcl,
-                timeout=timeout,
+            log_file_path_mapping: Dict[str, Path] = (
+                await stata_executor.execute_dofile_async(
+                    request.dofile_path,
+                    log_file_name,
+                    is_replace_log,
+                    enable_smcl,
+                    timeout=timeout,
+                )
             )
         text_log = log_file_path_mapping.get("text").as_posix()
-        logging.info(f"{request.dofile_path} is executed successfully. Log file path: {text_log}")
+        logging.info("Dofile executed successfully.")
     except RAMLimitExceededError as e:
-        logging.error(f"Out of max RAM limit: {e}")
+        logging.error("Out of max RAM limit: %s", e)
         return {"error": f"Out of max RAM limit: {e}"}
     except Exception as e:
-        logging.error(f"Failed to execute {request.dofile_path}. Error: {str(e)}")
+        logging.error("Failed to execute dofile.")
+        logging.debug("Execution exception details: %s", e)
         return {"error": str(e)}
 
     return _format_stata_do_result(
@@ -437,11 +452,11 @@ class _AdoInstallApproval(BaseModel):
 
 
 async def ado_package_install(
-        package: str,
-        source: str = "ssc",
-        is_replace: bool = False,
-        package_source_from: str = None,
-        ctx: Context = None,
+    package: str,
+    source: str = "ssc",
+    is_replace: bool = False,
+    package_source_from: str = None,
+    ctx: Context = None,
 ) -> str:
     """
     Install a Stata package from SSC, GitHub, or net.
@@ -505,11 +520,12 @@ async def ado_package_install(
 # STATA_MCP.TOOLS: Data Operation Tools
 # =============================================================================
 
+
 def get_data_info(
-        data_path: str,
-        vars_list: List[str] | None = None,
-        encoding: str = "utf-8",
-        head: int = 0,
+    data_path: str,
+    vars_list: List[str] | None = None,
+    encoding: str = "utf-8",
+    head: int = 0,
 ) -> str:
     """
     Return descriptive statistics for a supported data file.
@@ -542,13 +558,14 @@ def get_data_info(
 # STATA_MCP.TOOLS: File Management Tools
 # =============================================================================
 
+
 def read_log(
-        file_path: str,
-        encoding: str = "utf-8",
-        is_beta: bool = False,
-        *,
-        output_format: Literal["full", "core", "dict"] = "dict",
-        lines: int = 0,
+    file_path: str,
+    encoding: str = "utf-8",
+    is_beta: bool = False,
+    *,
+    output_format: Literal["full", "core", "dict"] = "dict",
+    lines: int = 0,
 ) -> str:
     """
     Read a Stata log file (.log or .smcl) and return its content.
@@ -587,18 +604,14 @@ def read_log(
     try:
         path.relative_to(config.STATA_MCP_FOLDER.path.resolve())
     except ValueError:
-        allowed_path = config.STATA_MCP_FOLDER.path.resolve()
         # Log security violation for audit purposes.
         # If this security warning appears, it may indicate that the current model has been compromised/poisoned.
         logging.warning(
-            f"[SECURITY VIOLATION] Attempted to access file outside allowed directory: "
-            f"requested_path='{file_path}', "
-            f"resolved_path='{path}', "
-            f"allowed_directory='{allowed_path}'"
+            "[SECURITY VIOLATION] Attempted to access file outside allowed directory."
         )
         raise PermissionError(
-            f"Access denied: File '{file_path}' is outside the allowed directory '{allowed_path}'. "
-            f"read_file can only read files within the stata-mcp-folder."
+            "Access denied: File is outside the allowed directory. "
+            "read_file can only read files within the stata-mcp-folder."
         )
 
     if not path.exists():
@@ -606,6 +619,7 @@ def read_log(
 
     if is_beta and config.IS_UNIX:
         from .stata import StataLog
+
         loger = StataLog.from_path(file_path, encoding=encoding)
         if output_format not in ["full", "core", "dict"]:
             raise ValueError(f"Invalid output_format: {output_format}")
@@ -619,15 +633,16 @@ def read_log(
                 return str(dict_data)
             if lines > 0:
                 return str(dict_data[:lines])
-            return str(dict_data[-abs(lines):])
+            return str(dict_data[-abs(lines) :])
     # if not beta version and Windows user using read file text directly.
     try:
         with open(path, "r", encoding=encoding) as file:
             log_content = file.read()
-        logging.info(f"Successfully read file: {file_path}")
+        logging.info("Successfully read file.")
         return _trim_lines(log_content, lines)
     except IOError as e:
-        logging.error(f"Failed to read file {file_path}: {str(e)}")
+        logging.error("Failed to read file.")
+        logging.debug("Read file exception details: %s", e)
         raise IOError(f"An error occurred while reading the file: {e}")
 
 
@@ -639,7 +654,7 @@ def _trim_lines(content: str, lines: int) -> str:
     all_lines = content.splitlines()
     if lines > 0:
         return "\n".join(all_lines[:lines])
-    return "\n".join(all_lines[-abs(lines):])
+    return "\n".join(all_lines[-abs(lines) :])
 
 
 def _is_within_allowed_directories(target_path: Path, allowed_dirs: List[Path]) -> bool:
@@ -739,7 +754,10 @@ def register_tools(server: FastMCP, profile: str = "all") -> None:
 
         tool_func: ToolFunc | None = meta.get("func")
         if tool_func is None:
-            logging.warning("Skipping tool '%s' because its registry entry has no callable func.", name)
+            logging.warning(
+                "Skipping tool '%s' because its registry entry has no callable func.",
+                name,
+            )
             continue
         server.tool(name=name, description=meta["description"])(tool_func)
 
@@ -759,18 +777,14 @@ def register_tools(server: FastMCP, profile: str = "all") -> None:
 
 __all__ = [
     "stata_mcp",
-
     # Functions (Core)
     "get_data_info",
     "stata_do",
     "register_tools",
-
     # Utilities
     "read_log",
     "ado_package_install",
 ]
 
 if config.IS_UNIX:
-    __all__.extend([
-        "help"
-    ])
+    __all__.extend(["help"])

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -73,7 +73,9 @@ IS_ASYNC_DO = "on"
     assert Config(config_file=config_path).IS_ASYNC_DO is False
 
 
-def test_async_do_max_parallel_config_reads_positive_integer(monkeypatch, tmp_path) -> None:
+def test_async_do_max_parallel_config_reads_positive_integer(
+    monkeypatch, tmp_path
+) -> None:
     config_path = tmp_path / "config.toml"
     config_path.write_text(
         """
@@ -92,7 +94,9 @@ MAX_ASYNC_DO = 5
     assert Config(config_file=config_path).MAX_ASYNC_DO == 3
 
 
-def test_async_do_max_parallel_config_rejects_invalid_values(monkeypatch, tmp_path) -> None:
+def test_async_do_max_parallel_config_rejects_invalid_values(
+    monkeypatch, tmp_path
+) -> None:
     config_path = tmp_path / "config.toml"
     config_path.write_text(
         """
@@ -340,6 +344,42 @@ strict_data_info_local_boundary = true
     )
 
     assert Config(config_file=config_path).STRICT_DATA_INFO_LOCAL_BOUNDARY is True
+
+
+def test_data_command_path_guard_defaults_to_disabled(tmp_path) -> None:
+    config = Config(config_file=tmp_path / "missing.toml")
+
+    assert config.ENABLE_DATA_COMMAND_PATH_GUARD is False
+
+
+def test_data_command_path_guard_reads_toml(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[SECURITY]
+enable_data_command_path_guard = true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    assert Config(config_file=config_path).ENABLE_DATA_COMMAND_PATH_GUARD is True
+
+
+def test_data_command_path_guard_env_var_overrides_toml(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[SECURITY]
+enable_data_command_path_guard = false
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("STATA_MCP__ENABLE_DATA_COMMAND_PATH_GUARD", "true")
+
+    assert Config(config_file=config_path).ENABLE_DATA_COMMAND_PATH_GUARD is True
 
 
 def test_linux_system_config_overrides_debug_config(

--- a/tests/test_get_data_info_security.py
+++ b/tests/test_get_data_info_security.py
@@ -171,7 +171,9 @@ def test_local_file_outside_working_dir_logs_security_violation(
     messages = _joined_log_messages(caplog)
     assert result == "Access denied: data file must be within the working directory."
     assert "[SECURITY VIOLATION]" in messages
-    assert "resolved_path" in messages
+    assert "resolved_path" not in messages
+    assert "requested_path" not in messages
+    assert "working_dir" not in messages
 
 
 def test_relative_local_file_is_resolved_from_working_dir(

--- a/tests/test_guard_data_path_auditor.py
+++ b/tests/test_guard_data_path_auditor.py
@@ -1,0 +1,180 @@
+"""Tests for the shared DataPathAuditor."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from stata_mcp.guard.data_path_auditor import (
+    IP_URL_ACCESS_DENIED,
+    LOCAL_ACCESS_DENIED,
+    NON_HTTPS_URL_ACCESS_DENIED,
+    URL_DOMAIN_ACCESS_DENIED,
+    URL_USERINFO_ACCESS_DENIED,
+    DataPathAuditor,
+)
+
+
+@pytest.fixture
+def working_dir(tmp_path: Path) -> Path:
+    work = tmp_path / "work"
+    work.mkdir()
+    return work
+
+
+@pytest.fixture
+def auditor(working_dir: Path) -> DataPathAuditor:
+    return DataPathAuditor(
+        working_dir=working_dir,
+        strict_local_boundary=True,
+        enable_url_guard=True,
+        allowed_url_domains=("example.com",),
+    )
+
+
+def test_local_file_within_working_dir_is_allowed(
+    auditor: DataPathAuditor, working_dir: Path
+) -> None:
+    data_file = working_dir / "data.csv"
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    result = auditor.validate_local_path(data_file.as_posix())
+
+    assert isinstance(result, Path)
+    assert result == data_file.resolve()
+
+
+def test_local_file_outside_working_dir_is_rejected(
+    auditor: DataPathAuditor, tmp_path: Path
+) -> None:
+    outside_file = tmp_path / "outside.csv"
+    outside_file.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    result = auditor.validate_local_path(outside_file.as_posix())
+
+    assert result == LOCAL_ACCESS_DENIED
+
+
+def test_relative_local_file_resolved_from_working_dir(
+    auditor: DataPathAuditor, working_dir: Path
+) -> None:
+    data_file = working_dir / "data.csv"
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    result = auditor.validate_local_path("data.csv")
+
+    assert isinstance(result, Path)
+    assert result == data_file.resolve()
+
+
+def test_relative_local_file_escaping_working_dir_is_rejected(
+    auditor: DataPathAuditor,
+) -> None:
+    result = auditor.validate_local_path("../outside.csv")
+
+    assert result == LOCAL_ACCESS_DENIED
+
+
+def test_local_boundary_disabled_allows_outside_path(
+    auditor: DataPathAuditor, tmp_path: Path
+) -> None:
+    permissive_auditor = DataPathAuditor(
+        working_dir=auditor.working_dir,
+        strict_local_boundary=False,
+        enable_url_guard=True,
+        allowed_url_domains=(),
+    )
+    outside_file = tmp_path / "outside.csv"
+    outside_file.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    result = permissive_auditor.validate_local_path(outside_file.as_posix())
+
+    assert isinstance(result, Path)
+    assert result == outside_file.resolve()
+
+
+def test_https_allowlisted_domain_is_allowed(auditor: DataPathAuditor) -> None:
+    result = auditor.validate_url("https://example.com/data.csv")
+
+    assert isinstance(result, tuple)
+    assert result == ("https://example.com/data.csv", "csv")
+
+
+def test_subdomain_of_allowlisted_domain_is_allowed(auditor: DataPathAuditor) -> None:
+    result = auditor.validate_url("https://sub.example.com/data.csv")
+
+    assert isinstance(result, tuple)
+    assert result[0] == "https://sub.example.com/data.csv"
+
+
+def test_non_allowlisted_domain_is_rejected(auditor: DataPathAuditor) -> None:
+    result = auditor.validate_url("https://evil.com/data.csv")
+
+    assert result == URL_DOMAIN_ACCESS_DENIED
+
+
+def test_http_scheme_is_rejected(auditor: DataPathAuditor) -> None:
+    result = auditor.validate_url("http://example.com/data.csv")
+
+    assert result == NON_HTTPS_URL_ACCESS_DENIED
+
+
+def test_ip_host_is_rejected(auditor: DataPathAuditor) -> None:
+    result = auditor.validate_url("https://192.168.1.1/data.csv")
+
+    assert result == IP_URL_ACCESS_DENIED
+
+
+def test_url_with_userinfo_is_rejected(auditor: DataPathAuditor) -> None:
+    result = auditor.validate_url("https://user:pass@example.com/data.csv")
+
+    assert result == URL_USERINFO_ACCESS_DENIED
+
+
+def test_url_guard_disabled_allows_any_url(auditor: DataPathAuditor) -> None:
+    permissive_auditor = DataPathAuditor(
+        working_dir=auditor.working_dir,
+        strict_local_boundary=True,
+        enable_url_guard=False,
+        allowed_url_domains=(),
+    )
+
+    result = permissive_auditor.validate_url("http://evil.com/data.csv")
+
+    assert isinstance(result, tuple)
+    assert result[0] == "http://evil.com/data.csv"
+
+
+def test_url_log_redacts_query_and_fragment(caplog, auditor: DataPathAuditor) -> None:
+    with caplog.at_level(logging.WARNING):
+        auditor.validate_url("https://evil.com/data.csv?token=secret#anchor")
+
+    messages = "\n".join(caplog.messages)
+    assert "requested_url='https://evil.com/data.csv'" in messages
+    assert "token=secret" not in messages
+    assert "#anchor" not in messages
+
+
+def test_url_log_redacts_userinfo(caplog, auditor: DataPathAuditor) -> None:
+    with caplog.at_level(logging.WARNING):
+        auditor.validate_url("https://user:pass@evil.com/data.csv?token=secret#anchor")
+
+    messages = "\n".join(caplog.messages)
+    assert "requested_url='https://evil.com/data.csv'" in messages
+    assert "user:pass@" not in messages
+    assert "token=secret" not in messages
+    assert "#anchor" not in messages
+
+
+def test_local_path_log_does_not_include_full_paths(
+    caplog, auditor: DataPathAuditor
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        auditor.validate_local_path("../outside.csv")
+
+    messages = "\n".join(caplog.messages)
+    assert "[SECURITY VIOLATION]" in messages
+    assert "requested_path" not in messages
+    assert "resolved_path" not in messages
+    assert "working_dir" not in messages
+    assert "outside.csv" not in messages

--- a/tests/test_guard_validator.py
+++ b/tests/test_guard_validator.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-
 from stata_mcp.guard.blacklist import DANGEROUS_COMMANDS, PACKAGE_MANAGEMENT_COMMANDS
 from stata_mcp.guard.validator import GuardValidator, PackageManagementGuardValidator
 
@@ -42,14 +37,13 @@ local pkgcmd "ssc"
 
     assert report.is_safe is False
     blocked_commands = {
-        item.content
-        for item in report.dangerous_items
-        if item.type == "command"
+        item.content for item in report.dangerous_items if item.type == "command"
     }
-    assert {"ssc", "net", "github", "adoupdate", "update"}.issubset(
-        blocked_commands
+    assert {"ssc", "net", "github", "adoupdate", "update"}.issubset(blocked_commands)
+    assert any(
+        item.type == "macro" and item.content == "`pkgcmd'"
+        for item in report.dangerous_items
     )
-    assert any(item.type == "macro" and item.content == "`pkgcmd'" for item in report.dangerous_items)
 
 
 def test_package_management_guard_rejects_dynamic_command_position_macro() -> None:
@@ -62,7 +56,9 @@ def test_package_management_guard_rejects_dynamic_command_position_macro() -> No
 
 
 def test_package_management_guard_allows_normal_analysis_commands() -> None:
-    report = PackageManagementGuardValidator().validate("sysuse auto\nregress price mpg")
+    report = PackageManagementGuardValidator().validate(
+        "sysuse auto\nregress price mpg"
+    )
 
     assert report.is_safe is True
 
@@ -70,60 +66,112 @@ def test_package_management_guard_allows_normal_analysis_commands() -> None:
 def test_colon_prefix_is_stripped_before_command_check() -> None:
     report = GuardValidator().validate("quietly: shell echo pwn")
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "shell" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
 
 
 def test_chained_colon_prefix_is_stripped_before_command_check() -> None:
     report = GuardValidator().validate("capture noisily: shell echo pwn")
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "shell" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
 
 
-def test_delimit_semicolon_is_rejected() -> None:
-    report = GuardValidator().validate("#delimit ;\ndisplay 1")
+def test_delimit_semicolon_is_normalized_before_validation() -> None:
+    report = GuardValidator().validate("#delimit ;\nshell whoami;\n#delimit cr")
     assert report.is_safe is False
-    assert any(item.content == "#delimit ;" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
 
 
 def test_macro_expansion_with_dangerous_local_is_flagged() -> None:
     code = 'local cmd "shell"\n`cmd\' "rm -rf /"'  # noqa: S608
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "`cmd'"
+        for item in report.dangerous_items
+    )
 
 
 def test_unquoted_dangerous_local_is_flagged() -> None:
     code = "local cmd shell\ndisplay `cmd'"
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "`cmd'"
+        for item in report.dangerous_items
+    )
 
 
 def test_compound_quoted_dangerous_local_is_flagged() -> None:
     code = "local cmd `\"shell\"'\ndisplay `cmd'"
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "`cmd'"
+        for item in report.dangerous_items
+    )
 
 
 def test_global_macro_expansion_with_dangerous_value_is_flagged() -> None:
     code = 'global cmd "shell"\ndisplay $cmd'
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "$cmd" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "$cmd"
+        for item in report.dangerous_items
+    )
 
 
 def test_macro_expansion_is_checked_across_entire_line() -> None:
     code = 'local cmd "shell"\ndisplay `cmd\''
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "`cmd'"
+        for item in report.dangerous_items
+    )
 
 
 def test_macro_expansion_with_safe_local_is_not_flagged() -> None:
     code = 'local cmd "regress"\n`cmd\' y x'
     report = GuardValidator().validate(code)
     assert report.is_safe is True
+
+
+def test_line_scoped_unresolved_macro_in_display_is_allowed() -> None:
+    report = GuardValidator().validate('display "$S_DATE"')
+
+    assert report.is_safe is True
+
+
+def test_unresolved_macro_in_command_position_fails_closed() -> None:
+    code = "local cmd : env STATA_CMD\n`cmd' whoami"
+
+    report = GuardValidator().validate(code)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "parse" and item.content == "unresolved-macro"
+        for item in report.dangerous_items
+    )
+
+
+def test_global_parser_diagnostic_fails_closed() -> None:
+    report = GuardValidator().validate('display "unterminated')
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "parse" and item.content == "unbalanced-quotes"
+        for item in report.dangerous_items
+    )
 
 
 def test_commented_local_definition_is_ignored() -> None:
@@ -142,58 +190,85 @@ def test_prefixed_local_definition_is_detected() -> None:
     code = 'qui local cmd "shell"\n`cmd\' "rm"'  # noqa: S608
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "`cmd'"
+        for item in report.dangerous_items
+    )
 
 
 def test_chained_colon_prefix_with_each_prefix_having_colon() -> None:
     report = GuardValidator().validate("capture: noisily: shell echo pwn")
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "shell" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
 
 
 def test_colon_prefix_with_space_before_colon() -> None:
     report = GuardValidator().validate("quietly : shell echo pwn")
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "shell" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
 
 
 def test_macro_with_argument_in_value_is_flagged() -> None:
     code = "local cmd shell echo pwn\n`cmd'"
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "`cmd'"
+        for item in report.dangerous_items
+    )
 
 
 def test_global_macro_with_argument_in_value_is_flagged() -> None:
     code = "global cmd shell echo pwn\n$cmd"
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "$cmd" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "$cmd"
+        for item in report.dangerous_items
+    )
 
 
 def test_global_macro_with_braces_is_flagged() -> None:
     code = 'global cmd "shell"\n${cmd}'
     report = GuardValidator().validate(code)
     assert report.is_safe is False
-    assert any(item.type == "macro" and item.content == "$cmd" for item in report.dangerous_items)
+    assert any(
+        item.type == "macro" and item.content == "$cmd"
+        for item in report.dangerous_items
+    )
 
 
 def test_inline_block_comment_does_not_hide_dangerous_command() -> None:
     report = GuardValidator().validate("/* */ shell whoami")
 
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "shell" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
 
 
 def test_multiline_block_comment_does_not_hide_dangerous_command() -> None:
     report = GuardValidator().validate("/* ignored\nignored */ !whoami")
 
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "!" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "!"
+        for item in report.dangerous_items
+    )
 
 
 def test_frame_prefix_is_stripped_before_command_check() -> None:
     report = GuardValidator().validate("frame default: shell whoami")
 
     assert report.is_safe is False
-    assert any(item.type == "command" and item.content == "shell" for item in report.dangerous_items)
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )

--- a/tests/test_guard_validator_data_commands.py
+++ b/tests/test_guard_validator_data_commands.py
@@ -1,0 +1,553 @@
+"""Tests for GuardValidator data-command path auditing."""
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from stata_mcp.guard.validator import GuardValidator
+
+
+@pytest.fixture
+def working_dir(tmp_path: Path) -> Path:
+    work = tmp_path / "work"
+    work.mkdir()
+    return work
+
+
+@pytest.fixture
+def enabled_config(working_dir: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        ENABLE_DATA_COMMAND_PATH_GUARD=True,
+        STRICT_DATA_INFO_LOCAL_BOUNDARY=True,
+        ENABLE_DATA_INFO_URL_GUARD=True,
+        DATA_INFO_ALLOWED_URL_DOMAINS=("example.com",),
+        WORKING_DIR=working_dir,
+    )
+
+
+@pytest.fixture
+def disabled_config(working_dir: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        ENABLE_DATA_COMMAND_PATH_GUARD=False,
+        STRICT_DATA_INFO_LOCAL_BOUNDARY=True,
+        ENABLE_DATA_INFO_URL_GUARD=True,
+        DATA_INFO_ALLOWED_URL_DOMAINS=("example.com",),
+        WORKING_DIR=working_dir,
+    )
+
+
+def test_data_command_with_safe_local_path_passes(
+    enabled_config, working_dir: Path
+) -> None:
+    data_file = working_dir / "data.csv"
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+    code = f'use "{data_file.as_posix()}"\nregress y x'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_data_command_with_prefixes_is_detected(
+    enabled_config, working_dir: Path
+) -> None:
+    data_file = working_dir / "data.csv"
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+    code = f'capture noisily: use "{data_file.as_posix()}"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_use_command_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'use "/etc/passwd"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/etc/passwd" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_import_delimited_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'import delimited "/tmp/secret.csv"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.csv" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_use_using_syntax_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'use price mpg using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_relative_path_escaping_working_dir_is_rejected(enabled_config) -> None:
+    code = 'use "../secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_url_command_with_disallowed_domain_is_rejected(enabled_config) -> None:
+    code = 'import excel "https://evil.com/data.xlsx"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "evil.com" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_url_command_with_http_scheme_is_rejected(enabled_config) -> None:
+    code = 'use "http://example.com/data.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_url_command_with_allowlisted_domain_passes(enabled_config) -> None:
+    code = 'import delimited "https://example.com/data.csv"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_data_command_path_guard_disabled_allows_outside_path(disabled_config) -> None:
+    code = 'use "/etc/passwd"'
+
+    report = GuardValidator().validate(code, config=disabled_config)
+
+    assert report.is_safe is True
+
+
+def test_data_command_path_guard_without_config_is_disabled() -> None:
+    code = 'use "/etc/passwd"'
+
+    report = GuardValidator().validate(code)
+
+    assert report.is_safe is True
+
+
+def test_data_command_path_violation_is_logged(
+    caplog,
+    enabled_config,
+) -> None:
+    code = 'use "https://evil.com/data.dta?token=secret"'
+
+    with caplog.at_level(logging.WARNING):
+        report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    messages = "\n".join(caplog.messages)
+    assert "[SECURITY VIOLATION]" in messages
+    assert "token=secret" not in messages
+    assert "evil.com" in messages
+
+
+def test_insheet_command_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'insheet using "/tmp/secret.csv"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_infile_command_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'infile "/tmp/secret.raw"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_infix_command_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'infix "/tmp/secret.raw"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_use_abbreviation_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'u "/etc/passwd"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_use_abbreviation_us_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'us "/etc/passwd"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_apply_command_is_not_treated_as_data_command(enabled_config) -> None:
+    code = 'apply "../secret.dta", replace'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_useful_word_is_not_treated_as_data_command(enabled_config) -> None:
+    code = 'useful_command "../secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_commented_data_command_is_ignored(enabled_config) -> None:
+    code = '* use "/etc/passwd"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_data_command_inside_block_comment_is_ignored(enabled_config) -> None:
+    code = '/* use "/etc/passwd" */'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_dangerous_command_still_detected_alongside_data_path(enabled_config) -> None:
+    code = 'shell rm -rf /\nuse "/etc/passwd"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "command" and item.content == "shell"
+        for item in report.dangerous_items
+    )
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_import_dbase_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'import dbase "/tmp/secret.dbf"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dbf" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_import_xml_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'import xml "/tmp/secret.xml"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_merge_using_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'merge 1:1 id using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_append_using_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'append using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_joinby_using_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'joinby id using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_merge_using_safe_local_path_passes(enabled_config, working_dir: Path) -> None:
+    data_file = working_dir / "secret.dta"
+    data_file.write_text("", encoding="utf-8")
+    code = f'merge 1:1 id using "{data_file.as_posix()}"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_import_with_prefixes_is_detected(enabled_config) -> None:
+    code = 'capture quietly: import dbase "/tmp/secret.dbf"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_merge_with_prefixes_is_detected(enabled_config) -> None:
+    code = 'capture quietly: merge 1:1 id using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_merge_abbreviation_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'mer 1:1 id using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_append_abbreviation_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'app using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+@pytest.mark.parametrize("abbrev", ["ap", "appe", "appen", "app"])
+def test_append_abbreviations_outside_working_dir_are_rejected(
+    enabled_config, abbrev: str
+) -> None:
+    code = f'{abbrev} using "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_insheet_abbreviation_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'insh using "/tmp/secret.csv"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.csv" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_append_using_multiple_files_audits_all_paths(enabled_config) -> None:
+    code = 'append using "/tmp/secret1.dta" "/tmp/secret2.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    data_path_items = [
+        item for item in report.dangerous_items if item.type == "data_path"
+    ]
+    assert len(data_path_items) == 2
+    assert any("/tmp/secret1.dta" in item.content for item in data_path_items)
+    assert any("/tmp/secret2.dta" in item.content for item in data_path_items)
+
+
+def test_continuation_use_using_outside_working_dir_is_rejected(enabled_config) -> None:
+    code = 'use price mpg ///\nusing "/tmp/secret.dta"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_local_macro_data_path_is_expanded_and_rejected(enabled_config) -> None:
+    code = 'local p "/tmp/secret.dta"\nuse "`p\'"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_global_macro_data_path_is_expanded_and_rejected(enabled_config) -> None:
+    code = 'global P /tmp/secret.dta\nuse "$P"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_unresolved_macro_data_path_is_rejected(enabled_config) -> None:
+    code = 'use "$P"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "$P" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_dynamic_macro_data_path_fails_closed(enabled_config) -> None:
+    code = 'local p : env HOME\nuse "`p\'"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "parse" and item.content == "unresolved-macro"
+        for item in report.dangerous_items
+    )
+    assert any(
+        item.type == "data_path" and "`p'" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_non_sensitive_line_scoped_diagnostic_does_not_fail_whole_file(
+    enabled_config,
+) -> None:
+    code = 'display "$S_DATE"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
+def test_compound_quoted_data_path_is_rejected(enabled_config) -> None:
+    code = 'use `"/tmp/secret.dta"\''
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.dta" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_import_using_parentheses_outside_working_dir_is_rejected(
+    enabled_config,
+) -> None:
+    code = 'import delimited using("/tmp/secret.csv")'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and "/tmp/secret.csv" in item.content
+        for item in report.dangerous_items
+    )
+
+
+def test_cd_is_rejected_when_data_command_path_guard_is_enabled(enabled_config) -> None:
+    code = "cd /tmp\nuse secret.dta"
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "context" and item.content == "cd"
+        for item in report.dangerous_items
+    )
+
+
+def test_cd_is_allowed_when_data_command_path_guard_is_disabled(
+    disabled_config,
+) -> None:
+    code = "cd /tmp\nuse secret.dta"
+
+    report = GuardValidator().validate(code, config=disabled_config)
+
+    assert report.is_safe is True
+
+
+def test_webuse_set_disallowed_url_is_rejected(enabled_config) -> None:
+    code = "webuse set http://127.0.0.1/private"
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(item.type == "data_path" for item in report.dangerous_items)
+
+
+def test_webuse_data_load_is_rejected_when_url_cannot_be_audited(
+    enabled_config,
+) -> None:
+    code = "webuse auto, clear"
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is False
+    assert any(
+        item.type == "data_path" and item.content == "webuse"
+        for item in report.dangerous_items
+    )

--- a/tests/test_mcp_servers_security_log.py
+++ b/tests/test_mcp_servers_security_log.py
@@ -1,0 +1,276 @@
+"""Tests for mcp_servers security-rejection log sanitization."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def stubbed_mcp_servers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Load stata_mcp.mcp_servers with isolated dependency stubs."""
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    home_dir.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home_dir)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("STATA_MCP_CONFIG_FILE", raising=False)
+
+    fastmcp_module = ModuleType("mcp.server.fastmcp")
+
+    class _FastMCP:
+        def __init__(self, *args, **kwargs) -> None:
+            self._tools = []
+
+        def tool(self, name: str, description: str):
+            def _decorator(func):
+                self._tools.append((name, func))
+                return func
+
+            return _decorator
+
+        def resource(self, uri: str, name: str, description: str):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+        def run(self, transport: str) -> None:
+            return None
+
+    class _Icon:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    class _Context:
+        pass
+
+    fastmcp_module.FastMCP = _FastMCP
+    fastmcp_module.Icon = _Icon
+    fastmcp_module.Context = _Context
+
+    mcp_module = ModuleType("mcp")
+    mcp_server_module = ModuleType("mcp.server")
+    mcp_server_module.fastmcp = fastmcp_module
+    mcp_module.server = mcp_server_module
+
+    monkeypatch.setitem(sys.modules, "mcp", mcp_module)
+    monkeypatch.setitem(sys.modules, "mcp.server", mcp_server_module)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_module)
+
+    monkeypatch.delitem(sys.modules, "stata_mcp.mcp_servers", raising=False)
+
+    return importlib.import_module("stata_mcp.mcp_servers")
+
+
+def test_prepare_stata_do_request_rejection_log_redacts_url_query(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    stubbed_mcp_servers,
+    tmp_path: Path,
+) -> None:
+    """The security-rejection log must not leak URL query parameters or full paths."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    fake_folder = SimpleNamespace(DO=work, TMP=tmp_path / "tmp")
+    fake_config = SimpleNamespace(
+        WORKING_DIR=work,
+        STATA_MCP_FOLDER=fake_folder,
+        IS_GUARD=True,
+        ENABLE_DATA_COMMAND_PATH_GUARD=True,
+        STRICT_DATA_INFO_LOCAL_BOUNDARY=True,
+        ENABLE_DATA_INFO_URL_GUARD=True,
+        DATA_INFO_ALLOWED_URL_DOMAINS=("example.com",),
+        IS_MONITOR=False,
+        MAX_RAM_MB=None,
+        LOGGING_ON=True,
+    )
+    monkeypatch.setattr(stubbed_mcp_servers, "config", fake_config)
+
+    dofile = work / "bad.do"
+    dofile.write_text(
+        'use "https://evil.com/data.dta?token=secret#anchor"\n',
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = stubbed_mcp_servers._prepare_stata_do_request(dofile.as_posix())
+
+    assert result["action"] == "Security check, dofile not executed"
+    # The caller-facing warning still contains the raw URL for diagnostics.
+    assert "token=secret" in result["warning"]
+
+    messages = "\n".join(caplog.messages)
+    assert "[SECURITY VIOLATION]" in messages
+    assert "token=secret" not in messages
+    assert "#anchor" not in messages
+    assert "evil.com/data.dta" in messages
+
+
+def test_prepare_stata_do_request_rejection_log_redacts_local_path(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    stubbed_mcp_servers,
+    tmp_path: Path,
+) -> None:
+    """The security-rejection log must not leak absolute local file paths."""
+    work = tmp_path / "work"
+    work.mkdir()
+    outside = tmp_path / "secret.dta"
+    outside.write_text("", encoding="utf-8")
+
+    fake_folder = SimpleNamespace(DO=work, TMP=tmp_path / "tmp")
+    fake_config = SimpleNamespace(
+        WORKING_DIR=work,
+        STATA_MCP_FOLDER=fake_folder,
+        IS_GUARD=True,
+        ENABLE_DATA_COMMAND_PATH_GUARD=True,
+        STRICT_DATA_INFO_LOCAL_BOUNDARY=True,
+        ENABLE_DATA_INFO_URL_GUARD=True,
+        DATA_INFO_ALLOWED_URL_DOMAINS=(),
+        IS_MONITOR=False,
+        MAX_RAM_MB=None,
+        LOGGING_ON=True,
+    )
+    monkeypatch.setattr(stubbed_mcp_servers, "config", fake_config)
+
+    dofile = work / "bad.do"
+    dofile.write_text(
+        f'use "{outside.as_posix()}"\n',
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = stubbed_mcp_servers._prepare_stata_do_request(dofile.as_posix())
+
+    assert result["action"] == "Security check, dofile not executed"
+    # The caller-facing warning still contains the raw path for diagnostics.
+    assert outside.as_posix() in result["warning"]
+
+    messages = "\n".join(caplog.messages)
+    assert "[SECURITY VIOLATION]" in messages
+    assert outside.as_posix() not in messages
+
+
+def test_read_log_rejection_log_redacts_local_path(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    stubbed_mcp_servers,
+    tmp_path: Path,
+) -> None:
+    """The read_log boundary rejection log must not leak absolute paths."""
+    statamcp_dir = tmp_path / "statamcp"
+    statamcp_dir.mkdir()
+    outside = tmp_path / "secret.log"
+    outside.write_text("log content", encoding="utf-8")
+
+    fake_folder = SimpleNamespace(path=statamcp_dir)
+    fake_config = SimpleNamespace(STATA_MCP_FOLDER=fake_folder)
+    monkeypatch.setattr(stubbed_mcp_servers, "config", fake_config)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(PermissionError):
+            stubbed_mcp_servers.read_log(outside.as_posix())
+
+    messages = "\n".join(caplog.messages)
+    assert "[SECURITY VIOLATION]" in messages
+    assert outside.as_posix() not in messages
+    assert "requested_path" not in messages
+    assert "resolved_path" not in messages
+    assert "allowed_directory" not in messages
+
+
+def test_sync_stata_do_execution_failure_log_redacts_path(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    stubbed_mcp_servers,
+    tmp_path: Path,
+) -> None:
+    """The sync execution-failure log must not leak absolute paths."""
+    work = tmp_path / "work"
+    work.mkdir()
+    dofile = work / "analysis.do"
+    dofile.write_text("di 1\n", encoding="utf-8")
+
+    fake_folder = SimpleNamespace(DO=work, TMP=tmp_path / "tmp", LOG=tmp_path / "log")
+    fake_config = SimpleNamespace(
+        WORKING_DIR=work,
+        STATA_MCP_FOLDER=fake_folder,
+        IS_GUARD=False,
+        IS_MONITOR=False,
+        MAX_RAM_MB=None,
+        LOGGING_ON=True,
+        STATA_CLI=Path("stata"),
+        IS_UNIX=True,
+    )
+    monkeypatch.setattr(stubbed_mcp_servers, "config", fake_config)
+
+    class _FailingExecutor:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        def execute_dofile(self, *args, **kwargs) -> None:
+            raise RuntimeError(f"failed to run {dofile.as_posix()}")
+
+    stata_module = importlib.import_module("stata_mcp.stata")
+    monkeypatch.setattr(stata_module, "StataDo", _FailingExecutor)
+
+    with caplog.at_level(logging.ERROR):
+        result = stubbed_mcp_servers._sync_stata_do(dofile.as_posix())
+
+    assert "error" in result
+    messages = "\n".join(caplog.messages)
+    assert "Failed to execute dofile." in messages
+    assert dofile.as_posix() not in messages
+
+
+def test_async_stata_do_execution_failure_log_redacts_path(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    stubbed_mcp_servers,
+    tmp_path: Path,
+) -> None:
+    """The async execution-failure log must not leak absolute paths."""
+    work = tmp_path / "work"
+    work.mkdir()
+    dofile = work / "analysis.do"
+    dofile.write_text("di 1\n", encoding="utf-8")
+
+    fake_folder = SimpleNamespace(DO=work, TMP=tmp_path / "tmp", LOG=tmp_path / "log")
+    fake_config = SimpleNamespace(
+        WORKING_DIR=work,
+        STATA_MCP_FOLDER=fake_folder,
+        IS_GUARD=False,
+        IS_MONITOR=False,
+        MAX_RAM_MB=None,
+        LOGGING_ON=True,
+        STATA_CLI=Path("stata"),
+        IS_UNIX=True,
+    )
+    monkeypatch.setattr(stubbed_mcp_servers, "config", fake_config)
+
+    class _FailingAsyncExecutor:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def execute_dofile_async(self, *args, **kwargs) -> None:
+            raise RuntimeError(f"failed to run {dofile.as_posix()}")
+
+    async_do_module = importlib.import_module("stata_mcp.stata.stata_do.async_do")
+    monkeypatch.setattr(async_do_module, "AsyncStataDo", _FailingAsyncExecutor)
+
+    with caplog.at_level(logging.ERROR):
+        result = asyncio.run(stubbed_mcp_servers._async_stata_do(dofile.as_posix()))
+
+    assert "error" in result
+    messages = "\n".join(caplog.messages)
+    assert "Failed to execute dofile." in messages
+    assert dofile.as_posix() not in messages

--- a/tests/test_parse_dofile.py
+++ b/tests/test_parse_dofile.py
@@ -365,9 +365,8 @@ def test_guard_catches_macro_obfuscated_shell():
 
     code = "`oops'shell rm -rf /tmp/x\n"
     validator = GuardValidator()
-    # raw source slips past the command check (line starts with a macro)
-    assert validator.validate(code).is_safe is True
-    # expanded source is caught
+    # GuardValidator expands source internally before checking commands.
+    assert validator.validate(code).is_safe is False
     assert validator.validate(expand_code(code)).is_safe is False
 
 

--- a/tests/test_stata_do_boundary.py
+++ b/tests/test_stata_do_boundary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import asyncio
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -18,7 +19,9 @@ from stata_mcp.stata.stata_do.do import StataDo
 def loaded_mcp_servers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Load mcp_servers with minimal external dependency stubs."""
     monkeypatch.setenv("HOME", (tmp_path / "home").as_posix())
-    monkeypatch.setitem(sys.modules, "tomli_w", SimpleNamespace(dump=lambda *args, **kwargs: None))
+    monkeypatch.setitem(
+        sys.modules, "tomli_w", SimpleNamespace(dump=lambda *args, **kwargs: None)
+    )
     monkeypatch.setitem(sys.modules, "pexpect", ModuleType("pexpect"))
 
     fastmcp_module = ModuleType("mcp.server.fastmcp")
@@ -63,7 +66,13 @@ def loaded_mcp_servers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     return importlib.import_module("stata_mcp.mcp_servers")
 
 
-def _configure_base(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, do_dir: Path, work_dir: Path, root: Path) -> None:
+def _configure_base(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_mcp_servers,
+    do_dir: Path,
+    work_dir: Path,
+    root: Path,
+) -> None:
     monkeypatch.setattr(
         loaded_mcp_servers,
         "config",
@@ -88,17 +97,31 @@ def _patch_stata_module(monkeypatch: pytest.MonkeyPatch, log_file: Path) -> Mock
     return fake_executor
 
 
-def test_is_within_allowed_directories_uses_input_path_directly(loaded_mcp_servers, tmp_path: Path):
+def test_is_within_allowed_directories_uses_input_path_directly(
+    loaded_mcp_servers, tmp_path: Path
+):
     allowed = tmp_path / "allowed"
     dofile = allowed / "nested" / "sample.do"
     dofile.parent.mkdir(parents=True)
     dofile.write_text("display 1")
 
-    assert loaded_mcp_servers._is_within_allowed_directories(dofile.resolve(), [allowed.resolve()]) is True
-    assert loaded_mcp_servers._is_within_allowed_directories((tmp_path / "outside.do").resolve(), [allowed.resolve()]) is False
+    assert (
+        loaded_mcp_servers._is_within_allowed_directories(
+            dofile.resolve(), [allowed.resolve()]
+        )
+        is True
+    )
+    assert (
+        loaded_mcp_servers._is_within_allowed_directories(
+            (tmp_path / "outside.do").resolve(), [allowed.resolve()]
+        )
+        is False
+    )
 
 
-def test_stata_do_allows_dofile_in_working_dir(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_allows_dofile_in_working_dir(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "do"
     do_dir.mkdir()
     work_dir = tmp_path / "work"
@@ -349,7 +372,9 @@ def test_mcp_async_stata_do_releases_parallel_slot_after_error(
 
     assert calls == ["failure_0.do", "failure_1.do"]
     assert results[0] == {"error": "first failed"}
-    assert results[1]["log_file_path"]["text"] == (tmp_path / "failure_1.log").as_posix()
+    assert (
+        results[1]["log_file_path"]["text"] == (tmp_path / "failure_1.log").as_posix()
+    )
 
 
 def test_mcp_async_do_semaphore_is_recreated_when_limit_changes(
@@ -421,7 +446,9 @@ def test_mcp_async_do_semaphore_falls_back_to_default_for_invalid_runtime_limit(
     assert tracker["max_active"] == 3
 
 
-def test_stata_do_rejects_dofile_outside_whitelist(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_rejects_dofile_outside_whitelist(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "do"
     do_dir.mkdir()
     work_dir = tmp_path / "work"
@@ -440,7 +467,9 @@ def test_stata_do_rejects_dofile_outside_whitelist(monkeypatch: pytest.MonkeyPat
     assert work_dir.resolve().as_posix() in result["allowed_directories"]
 
 
-def test_stata_do_rejects_symlink_pointing_outside(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_rejects_symlink_pointing_outside(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "do"
     do_dir.mkdir()
     work_dir = tmp_path / "work"
@@ -460,7 +489,9 @@ def test_stata_do_rejects_symlink_pointing_outside(monkeypatch: pytest.MonkeyPat
     assert result["error"].startswith("Access denied")
 
 
-def test_stata_do_rejects_path_traversal(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_rejects_path_traversal(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "do"
     do_dir.mkdir()
     work_dir = tmp_path / "work"
@@ -480,7 +511,9 @@ def test_stata_do_rejects_path_traversal(monkeypatch: pytest.MonkeyPatch, loaded
     assert result["error"].startswith("Access denied")
 
 
-def test_stata_do_skips_missing_allowed_directories(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_skips_missing_allowed_directories(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "missing-do"
     work_dir = tmp_path / "work"
     work_dir.mkdir()
@@ -499,7 +532,9 @@ def test_stata_do_skips_missing_allowed_directories(monkeypatch: pytest.MonkeyPa
     assert result["log_file_path"]["text"] == log_file.as_posix()
 
 
-def test_stata_do_allows_dofile_in_do_directory(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_allows_dofile_in_do_directory(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "do"
     do_dir.mkdir()
     work_dir = tmp_path / "work"
@@ -519,7 +554,9 @@ def test_stata_do_allows_dofile_in_do_directory(monkeypatch: pytest.MonkeyPatch,
     assert result["log_file_path"]["text"] == log_file.as_posix()
 
 
-def test_stata_do_rejects_when_allowed_directories_are_empty(monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path):
+def test_stata_do_rejects_when_allowed_directories_are_empty(
+    monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
+):
     do_dir = tmp_path / "missing-do"
     work_dir = tmp_path / "missing-work"
     outside_dir = tmp_path / "outside"
@@ -614,6 +651,122 @@ def test_api_stata_do_rejects_package_management_when_guard_is_disabled(
 
     assert result["action"] == "Security check, dofile not executed"
     stata_executor.assert_not_called()
+
+
+class TestApiStataDoSecurityLog:
+    """Tests that api/stata_do security logs do not leak full paths."""
+
+    def _build_runtime(self, tmp_path: Path, do_dir: Path, work_dir: Path):
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                STATA_MCP_FOLDER=SimpleNamespace(DO=do_dir),
+                WORKING_DIR=work_dir,
+                IS_GUARD=True,
+                IS_MONITOR=False,
+                ENABLE_DATA_COMMAND_PATH_GUARD=True,
+                STRICT_DATA_INFO_LOCAL_BOUNDARY=True,
+                ENABLE_DATA_INFO_URL_GUARD=True,
+                DATA_INFO_ALLOWED_URL_DOMAINS=(),
+            ),
+            stata_cli="stata",
+            log_base_path=tmp_path,
+            is_unix=True,
+            cwd=work_dir,
+        )
+
+    def test_api_stata_do_boundary_warning_log_redacts_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        do_dir = tmp_path / "do"
+        do_dir.mkdir()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dofile = outside / "blocked.do"
+        dofile.write_text("display 1")
+
+        stata_do_api = importlib.import_module("stata_mcp.api.stata_do")
+        runtime = self._build_runtime(tmp_path, do_dir, work_dir)
+        monkeypatch.setattr(
+            stata_do_api,
+            "create_runtime_context",
+            lambda **kwargs: runtime,
+        )
+        monkeypatch.setattr(stata_do_api, "StataDo", Mock())
+
+        with caplog.at_level(logging.WARNING):
+            result = stata_do_api.stata_do(dofile.as_posix())
+
+        assert result["error"].startswith("Access denied")
+        messages = "\n".join(caplog.messages)
+        assert "[SECURITY VIOLATION]" in messages
+        assert dofile.as_posix() not in messages
+        assert work_dir.as_posix() not in messages
+
+    def test_api_stata_do_security_rejection_log_redacts_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        do_dir = tmp_path / "do"
+        do_dir.mkdir()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        dofile = work_dir / "bad.do"
+        dofile.write_text("shell rm -rf /")
+
+        stata_do_api = importlib.import_module("stata_mcp.api.stata_do")
+        runtime = self._build_runtime(tmp_path, do_dir, work_dir)
+        monkeypatch.setattr(
+            stata_do_api,
+            "create_runtime_context",
+            lambda **kwargs: runtime,
+        )
+        monkeypatch.setattr(stata_do_api, "StataDo", Mock())
+
+        with caplog.at_level(logging.WARNING):
+            result = stata_do_api.stata_do(dofile.as_posix())
+
+        assert result["action"] == "Security check, dofile not executed"
+        messages = "\n".join(caplog.messages)
+        assert "[SECURITY VIOLATION]" in messages
+        assert dofile.as_posix() not in messages
+        assert work_dir.as_posix() not in messages
+
+    def test_api_stata_do_read_failure_log_redacts_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        do_dir = tmp_path / "do"
+        do_dir.mkdir()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        # A directory at the dofile path causes read_text to fail.
+        dofile = work_dir / "bad"
+        dofile.mkdir()
+
+        stata_do_api = importlib.import_module("stata_mcp.api.stata_do")
+        runtime = self._build_runtime(tmp_path, do_dir, work_dir)
+        monkeypatch.setattr(
+            stata_do_api,
+            "create_runtime_context",
+            lambda **kwargs: runtime,
+        )
+        monkeypatch.setattr(stata_do_api, "StataDo", Mock())
+
+        with caplog.at_level(logging.ERROR):
+            result = stata_do_api.stata_do(dofile.as_posix())
+
+        assert result["error"].startswith("Failed to read dofile for security check")
+        messages = "\n".join(caplog.messages)
+        assert dofile.as_posix() not in messages
 
 
 class TestValidateLogName:


### PR DESCRIPTION
## Summary

Depends on #90. This wires the new dofile parser contract into GuardValidator and the data path boundary checks.

- use `expand_code_for_security()` inside GuardValidator
- reject global parser diagnostics with `requires_global_fail_closed`
- reject line-scoped parser uncertainty only on sensitive commands, including unresolved macro in command position
- audit data-loading/context-mutating commands via `ParsedCommand.data_paths`
- share local path and URL policy between `get_data_info` and guard through `DataPathAuditor`

## Verification

- `uv run pytest -q tests/test_parse_dofile.py tests/test_guard_validator.py tests/test_guard_validator_data_commands.py tests/test_guard_data_path_auditor.py` -> 196 passed
- `uv run pytest -q` -> 612 passed
- `uv run --with flake8 flake8 ... --extend-ignore=E501,W291,E203` -> passed
- `git diff --check` -> passed
