### PR TITLE
Add context-aware tool configuration

### DIFF
--- a/src/stata_mcp/_data_info_metrics.py
+++ b/src/stata_mcp/_data_info_metrics.py
@@ -15,10 +15,10 @@ def normalize_data_info_metrics(value: Any) -> tuple[str, ...]:
         return DEFAULT_DATA_INFO_METRICS
     if isinstance(value, str):
         values = value.split(",")
-    elif isinstance(value, (list, tuple, set)):
+    elif isinstance(value, (list, tuple)):
         values = value
     else:
-        raise TypeError("Expected a comma-separated string or string collection.")
+        raise TypeError("Expected a comma-separated string, list, or tuple.")
 
     additional_metrics: list[str] = []
     for item in values:

--- a/src/stata_mcp/_data_info_metrics.py
+++ b/src/stata_mcp/_data_info_metrics.py
@@ -1,0 +1,32 @@
+"""Shared normalization rules for data-info summary metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_DATA_INFO_METRICS = ("obs", "mean", "stderr", "min", "max")
+OPTIONAL_DATA_INFO_METRICS = ("med", "q1", "q3", "skewness", "kurtosis")
+DATA_INFO_METRICS = DEFAULT_DATA_INFO_METRICS + OPTIONAL_DATA_INFO_METRICS
+
+
+def normalize_data_info_metrics(value: Any) -> tuple[str, ...]:
+    """Keep mandatory metrics and append supported extras in caller order."""
+    if value is None:
+        return DEFAULT_DATA_INFO_METRICS
+    if isinstance(value, str):
+        values = value.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        values = value
+    else:
+        raise TypeError("Expected a comma-separated string or string collection.")
+
+    additional_metrics: list[str] = []
+    for item in values:
+        metric = str(item).strip().lower()
+        if (
+            metric in OPTIONAL_DATA_INFO_METRICS
+            and metric not in additional_metrics
+        ):
+            additional_metrics.append(metric)
+
+    return DEFAULT_DATA_INFO_METRICS + tuple(additional_metrics)

--- a/src/stata_mcp/api/get_data_info.py
+++ b/src/stata_mcp/api/get_data_info.py
@@ -21,6 +21,7 @@ from .._diagnostic_logging import (
     source_reference,
     utf8_size,
 )
+from ..config import ToolContext
 from ..data_info import get_data_handler
 from ..guard.data_path_auditor import DataPathAuditor
 from ._runtime import create_runtime_context
@@ -34,7 +35,8 @@ def _get_data_info_impl(
     encoding: str = "utf-8",
     config_file: str | Path | None = None,
     *,
-    head: int = 0,
+    head: int | None = None,
+    tool_context: ToolContext = "api",
     request_id: str | None = None,
 ) -> str:
     """Return descriptive statistics for a supported dataset."""
@@ -56,12 +58,14 @@ def _get_data_info_impl(
     try:
         stage_started_at = time.perf_counter()
         runtime = create_runtime_context(config_file=config_file)
+        data_info_config = runtime.config.get_data_info_config(tool_context)
+        resolved_head = data_info_config.heads if head is None else head
         log_event(
             logger,
             logging.DEBUG,
             "get_data_info.runtime.ready",
             active_request_id,
-            cache_enabled=runtime.config.DATA_INFO_IS_CACHE,
+            cache_enabled=data_info_config.is_cache,
             duration_ms=elapsed_ms(stage_started_at),
         )
         auditor = DataPathAuditor(
@@ -155,8 +159,12 @@ def _get_data_info_impl(
             vars_list,
             encoding=encoding,
             cache_dir=runtime.tmp_base_path,
-            head=head,
-            is_cache=runtime.config.DATA_INFO_IS_CACHE,
+            head=resolved_head,
+            is_cache=data_info_config.is_cache,
+            metrics=data_info_config.metrics,
+            string_keep_number=data_info_config.string_keep_number,
+            decimal_places=data_info_config.decimal_places,
+            hash_length=data_info_config.hash_length,
             request_id=active_request_id,
         )
         log_event(
@@ -240,6 +248,9 @@ def get_data_info(
     vars_list: List[str] | None = None,
     encoding: str = "utf-8",
     config_file: str | Path | None = None,
+    *,
+    head: int | None = None,
+    tool_context: ToolContext = "api",
 ) -> str:
     """Return descriptive statistics for a supported dataset."""
     return _get_data_info_impl(
@@ -247,4 +258,6 @@ def get_data_info(
         vars_list=vars_list,
         encoding=encoding,
         config_file=config_file,
+        head=head,
+        tool_context=tool_context,
     )

--- a/src/stata_mcp/api/get_data_info.py
+++ b/src/stata_mcp/api/get_data_info.py
@@ -73,6 +73,11 @@ def _get_data_info_impl(
             strict_local_boundary=runtime.config.STRICT_DATA_INFO_LOCAL_BOUNDARY,
             enable_url_guard=runtime.config.ENABLE_DATA_INFO_URL_GUARD,
             allowed_url_domains=runtime.config.DATA_INFO_ALLOWED_URL_DOMAINS,
+            additional_allowed_dirs=getattr(
+                runtime.config,
+                "ADDITIONAL_ALLOWED_DIRS",
+                (),
+            ),
         )
 
         stage_started_at = time.perf_counter()

--- a/src/stata_mcp/api/read_log.py
+++ b/src/stata_mcp/api/read_log.py
@@ -31,10 +31,19 @@ def read_log(
     path = Path(file_path).expanduser().resolve()
 
     if runtime.config.STRICT_READ_LOG_BOUNDARY:
-        allowed_base = runtime.config.STATA_MCP_FOLDER.path.resolve()
-        try:
-            path.relative_to(allowed_base)
-        except ValueError:
+        allowed_dirs = (
+            runtime.config.STATA_MCP_FOLDER.path,
+            *getattr(runtime.config, "ADDITIONAL_ALLOWED_DIRS", ()),
+        )
+        is_allowed = False
+        for allowed_dir in allowed_dirs:
+            try:
+                path.relative_to(allowed_dir.resolve())
+                is_allowed = True
+                break
+            except ValueError:
+                continue
+        if not is_allowed:
             logger.warning(
                 "[SECURITY VIOLATION] read_log outside allowed directory: %s",
                 path,

--- a/src/stata_mcp/api/stata_do.py
+++ b/src/stata_mcp/api/stata_do.py
@@ -82,6 +82,7 @@ def _stata_do(
     candidate_allowed_dirs = [
         runtime.config.STATA_MCP_FOLDER.DO,
         runtime.config.WORKING_DIR,
+        *getattr(runtime.config, "ADDITIONAL_ALLOWED_DIRS", ()),
     ]
     allowed_dirs: list[Path] = []
     for candidate_dir in candidate_allowed_dirs:

--- a/src/stata_mcp/api/stata_help.py
+++ b/src/stata_mcp/api/stata_help.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 
+from ..config import ToolContext
 from ..stata import StataHelp
 from ._runtime import create_runtime_context
 
@@ -17,13 +18,18 @@ def stata_help(
     cmd: str,
     config_file: str | Path | None = None,
     replace: bool = False,
+    *,
+    tool_context: ToolContext = "api",
 ) -> str:
     """Return help content for a Stata command through a one-shot helper."""
     runtime = create_runtime_context(config_file=config_file, require_stata=True)
+    help_config = runtime.config.get_help_config(tool_context)
     help_reader = StataHelp(
         stata_cli=runtime.stata_cli,
         project_tmp_dir=runtime.tmp_base_path,
         cache_dir=runtime.config.HELP_CACHE_DIR,
         config=runtime.config,
+        is_cache=help_config.is_cache,
+        is_save=help_config.is_save,
     )
     return help_reader.help(cmd, replace=replace)

--- a/src/stata_mcp/cli/_handlers.py
+++ b/src/stata_mcp/cli/_handlers.py
@@ -114,6 +114,7 @@ def handle_tool(args: Namespace) -> int:
             result = stata_help(
                 cmd=args.stata_command,
                 replace=args.replace,
+                tool_context="cli",
                 **config_kwargs,
             )
         elif args.tool_action == "data-info":
@@ -121,6 +122,8 @@ def handle_tool(args: Namespace) -> int:
                 data_path=args.data_path,
                 vars_list=args.vars_list,
                 encoding=args.encoding,
+                head=getattr(args, "heads", None),
+                tool_context="cli",
                 **config_kwargs,
             )
         elif args.tool_action == "read-log":

--- a/src/stata_mcp/cli/_parsers.py
+++ b/src/stata_mcp/cli/_parsers.py
@@ -242,6 +242,17 @@ def add_tool_parser(subparsers: argparse._SubParsersAction) -> argparse.Argument
         default=None,
         help="Optional variable names to inspect",
     )
+    tool_data_info_parser.add_argument(
+        "--heads",
+        type=int,
+        default=None,
+        metavar="ROWS",
+        help=(
+            "Preview rows: positive values show the first rows, negative values "
+            "show the last rows, and 0 disables previews "
+            "(default: CLI.TOOLS.DATA_INFO.heads or 5)"
+        ),
+    )
 
     tool_read_log_parser = tool_subparsers.add_parser(
         "read-log",

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -11,10 +11,7 @@ import logging
 import os
 import platform
 import re
-import shutil
-import stat
 import sys
-import tempfile
 import tomllib
 from dataclasses import dataclass
 from functools import cached_property
@@ -183,7 +180,11 @@ class Config:
                 )
                 return
 
-            cls._replace_config_text(target_file, migrated_content)
+            cls._replace_config_text(
+                target_file,
+                migrated_content,
+                expected_content=content,
+            )
             logger.info(
                 "Migrated legacy [data_info] to [DATA_INFO] in %s.",
                 config_file,
@@ -306,60 +307,72 @@ class Config:
         return multiline_delimiter
 
     @staticmethod
-    def _replace_config_text(config_file: Path, content: str) -> None:
-        """Atomically replace config text while preserving file metadata."""
-        temporary_path: Path | None = None
-        try:
-            original_stat = config_file.stat()
-            with tempfile.NamedTemporaryFile(
-                mode="wb",
-                dir=config_file.parent,
-                prefix=f".{config_file.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as temporary_file:
-                temporary_path = Path(temporary_file.name)
-                temporary_file.write(content.encode("utf-8"))
-                temporary_file.flush()
-                os.fsync(temporary_file.fileno())
+    def _replace_config_text(
+        config_file: Path,
+        content: str,
+        *,
+        expected_content: str | None = None,
+    ) -> None:
+        """Patch equal-length text in place so all file metadata stays attached."""
+        replacement_bytes = content.encode("utf-8")
+        expected_bytes = (
+            config_file.read_bytes()
+            if expected_content is None
+            else expected_content.encode("utf-8")
+        )
+        if len(replacement_bytes) != len(expected_bytes):
+            raise ValueError("config migration must preserve the file length")
 
-            if hasattr(os, "chown"):
-                temporary_stat = temporary_path.stat()
-                target_user_id = (
-                    original_stat.st_uid
-                    if temporary_stat.st_uid != original_stat.st_uid
-                    else -1
-                )
-                target_group_id = (
-                    original_stat.st_gid
-                    if temporary_stat.st_gid != original_stat.st_gid
-                    else -1
-                )
-                if target_user_id != -1 or target_group_id != -1:
-                    os.chown(
-                        temporary_path,
-                        target_user_id,
-                        target_group_id,
-                    )
-            shutil.copystat(config_file, temporary_path, follow_symlinks=True)
+        difference_indices = [
+            index
+            for index, (original_byte, replacement_byte) in enumerate(
+                zip(expected_bytes, replacement_bytes)
+            )
+            if original_byte != replacement_byte
+        ]
+        if not difference_indices:
+            return
+        patch_start = difference_indices[0]
+        patch_end = difference_indices[-1] + 1
+        original_patch = expected_bytes[patch_start:patch_end]
+        replacement_patch = replacement_bytes[patch_start:patch_end]
+        if original_patch != b"data_info" or replacement_patch != b"DATA_INFO":
+            raise ValueError("config migration may only rename the data-info header")
 
-            temporary_stat = temporary_path.stat()
-            if stat.S_IMODE(temporary_stat.st_mode) != stat.S_IMODE(
-                original_stat.st_mode
-            ):
-                raise OSError("temporary config file mode does not match the original")
-            if hasattr(os, "chown") and (
-                temporary_stat.st_uid != original_stat.st_uid
-                or temporary_stat.st_gid != original_stat.st_gid
-            ):
-                raise OSError(
-                    "temporary config file ownership does not match the original"
-                )
-            os.replace(temporary_path, config_file)
-        except Exception:
-            if temporary_path is not None:
-                temporary_path.unlink(missing_ok=True)
-            raise
+        with open(config_file, "r+b") as config_stream:
+            current_bytes = config_stream.read()
+            if current_bytes == replacement_bytes:
+                return
+            if current_bytes != expected_bytes:
+                raise OSError("config file changed while migration was in progress")
+
+            try:
+                config_stream.seek(patch_start)
+                written_bytes = config_stream.write(replacement_patch)
+                if written_bytes != len(replacement_patch):
+                    raise OSError("config migration wrote an incomplete header")
+                config_stream.flush()
+                os.fsync(config_stream.fileno())
+                config_stream.seek(0)
+                if config_stream.read() != replacement_bytes:
+                    raise OSError("config migration verification failed")
+            except Exception as write_error:
+                try:
+                    config_stream.seek(patch_start)
+                    rollback_bytes = config_stream.write(original_patch)
+                    if rollback_bytes != len(original_patch):
+                        raise OSError("config migration rollback was incomplete")
+                    config_stream.flush()
+                    os.fsync(config_stream.fileno())
+                    config_stream.seek(0)
+                    if config_stream.read() != expected_bytes:
+                        raise OSError("config migration rollback verification failed")
+                except Exception as rollback_error:
+                    raise OSError(
+                        "config migration failed "
+                        f"({write_error}); rollback also failed ({rollback_error})"
+                    ) from write_error
+                raise
 
     @cached_property
     def config(self) -> dict[str, Any]:

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -20,25 +20,16 @@ from typing import Any, Literal, Optional, Union
 
 import tomli_w
 
+from ._data_info_metrics import (
+    DEFAULT_DATA_INFO_METRICS,
+    normalize_data_info_metrics,
+)
 from .core.types import StataCLINotFoundError
 from .stata import StataFinder
 
 logger = logging.getLogger(__name__)
 
 ToolContext = Literal["api", "cli", "mcp"]
-DATA_INFO_METRICS = (
-    "obs",
-    "mean",
-    "stderr",
-    "min",
-    "max",
-    "med",
-    "q1",
-    "q3",
-    "skewness",
-    "kurtosis",
-)
-DEFAULT_DATA_INFO_METRICS = ("obs", "mean", "stderr", "min", "max")
 LEGACY_DATA_INFO_HEADER_PATTERN = re.compile(
     r"^(?P<indent>[ \t]*)"
     r"\[(?P<inner_leading>[ \t]*)(?P<quote>[\"']?)"
@@ -703,13 +694,7 @@ class Config:
 
     @staticmethod
     def _to_metrics(value) -> tuple[str, ...]:
-        metrics = Config._to_str_tuple(value)
-        normalized_metrics = tuple(metric.lower() for metric in metrics)
-        if not normalized_metrics:
-            raise ValueError("At least one data-info metric is required.")
-        if any(metric not in DATA_INFO_METRICS for metric in normalized_metrics):
-            raise ValueError("Unsupported data-info metric.")
-        return tuple(dict.fromkeys(normalized_metrics))
+        return normalize_data_info_metrics(value)
 
     @staticmethod
     def _normalize_tool_context(context: ToolContext | None) -> ToolContext:

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -170,19 +170,8 @@ class Config:
                 )
                 return
 
-            def replace_header(match: re.Match[str]) -> str:
-                quote = match.group("quote")
-                return (
-                    f"{match.group('indent')}[{quote}DATA_INFO{quote}]"
-                    f"{match.group('suffix')}{match.group('carriage_return')}"
-                )
-
-            migrated_content, replacement_count = (
-                LEGACY_DATA_INFO_HEADER_PATTERN.subn(
-                    replace_header,
-                    content,
-                    count=1,
-                )
+            migrated_content, replacement_count = cls._replace_legacy_data_info_header(
+                content
             )
             if replacement_count != 1:
                 logger.warning(
@@ -229,6 +218,91 @@ class Config:
                 type(error).__name__,
                 error,
             )
+
+    @classmethod
+    def _replace_legacy_data_info_header(cls, content: str) -> tuple[str, int]:
+        """Replace a real table header while ignoring TOML multiline strings."""
+        migrated_lines: list[str] = []
+        multiline_delimiter: str | None = None
+        replacement_count = 0
+
+        for line in content.splitlines(keepends=True):
+            line_body = line[:-1] if line.endswith("\n") else line
+            line_ending = "\n" if line.endswith("\n") else ""
+            migrated_line_body = line_body
+
+            if multiline_delimiter is None and replacement_count == 0:
+                match = LEGACY_DATA_INFO_HEADER_PATTERN.fullmatch(line_body)
+                if match is not None:
+                    quote = match.group("quote")
+                    migrated_line_body = (
+                        f"{match.group('indent')}[{quote}DATA_INFO{quote}]"
+                        f"{match.group('suffix')}"
+                        f"{match.group('carriage_return')}"
+                    )
+                    replacement_count = 1
+
+            multiline_delimiter = cls._toml_multiline_delimiter_after_line(
+                migrated_line_body,
+                multiline_delimiter,
+            )
+            migrated_lines.append(migrated_line_body + line_ending)
+
+        return "".join(migrated_lines), replacement_count
+
+    @staticmethod
+    def _toml_multiline_delimiter_after_line(
+        line: str,
+        multiline_delimiter: str | None,
+    ) -> str | None:
+        """Track whether the next TOML line starts inside a multiline string."""
+        index = 0
+        while index < len(line):
+            if multiline_delimiter is not None:
+                delimiter_index = line.find(multiline_delimiter, index)
+                if delimiter_index < 0:
+                    return multiline_delimiter
+                if multiline_delimiter == '"""':
+                    preceding_backslashes = 0
+                    cursor = delimiter_index - 1
+                    while cursor >= 0 and line[cursor] == "\\":
+                        preceding_backslashes += 1
+                        cursor -= 1
+                    if preceding_backslashes % 2 == 1:
+                        index = delimiter_index + len(multiline_delimiter)
+                        continue
+                index = delimiter_index + len(multiline_delimiter)
+                multiline_delimiter = None
+                continue
+
+            if line[index] == "#":
+                break
+            if line.startswith('"""', index):
+                multiline_delimiter = '"""'
+                index += 3
+                continue
+            if line.startswith("'''", index):
+                multiline_delimiter = "'''"
+                index += 3
+                continue
+            if line[index] == '"':
+                index += 1
+                while index < len(line):
+                    if line[index] == "\\":
+                        index += 2
+                        continue
+                    if line[index] == '"':
+                        index += 1
+                        break
+                    index += 1
+                continue
+            if line[index] == "'":
+                closing_quote = line.find("'", index + 1)
+                index = len(line) if closing_quote < 0 else closing_quote + 1
+                continue
+            index += 1
+
+        return multiline_delimiter
 
     @staticmethod
     def _replace_config_text(config_file: Path, content: str) -> None:

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -10,7 +10,10 @@
 import logging
 import os
 import platform
+import re
+import stat
 import sys
+import tempfile
 import tomllib
 from dataclasses import dataclass
 from functools import cached_property
@@ -38,6 +41,13 @@ DATA_INFO_METRICS = (
     "kurtosis",
 )
 DEFAULT_DATA_INFO_METRICS = ("obs", "mean", "stderr", "min", "max")
+LEGACY_DATA_INFO_HEADER_PATTERN = re.compile(
+    r"^(?P<indent>[ \t]*)"
+    r"\[(?P<quote>[\"']?)data_info(?P=quote)\]"
+    r"(?P<suffix>[ \t]*(?:#[^\r\n]*)?)"
+    r"(?P<carriage_return>\r?)$",
+    re.MULTILINE,
+)
 
 
 @dataclass(frozen=True)
@@ -137,6 +147,113 @@ class Config:
                 )
                 if path is not None
             )
+
+        for active_config_file in dict.fromkeys(self.config_files):
+            self._migrate_legacy_data_info_section(active_config_file)
+
+    @classmethod
+    def _migrate_legacy_data_info_section(cls, config_file: Path) -> None:
+        """Rename `[data_info]` without making configuration loading fail."""
+        try:
+            target_file = config_file.resolve(strict=True)
+            content = target_file.read_bytes().decode("utf-8")
+            config_data = tomllib.loads(content)
+            legacy_section = config_data.get("data_info")
+            if not isinstance(legacy_section, dict):
+                return
+            if "DATA_INFO" in config_data:
+                logger.warning(
+                    "Could not automatically migrate legacy [data_info] in %s: "
+                    "both [data_info] and [DATA_INFO] exist; keeping both to "
+                    "avoid overwriting configuration.",
+                    config_file,
+                )
+                return
+
+            def replace_header(match: re.Match[str]) -> str:
+                quote = match.group("quote")
+                return (
+                    f"{match.group('indent')}[{quote}DATA_INFO{quote}]"
+                    f"{match.group('suffix')}{match.group('carriage_return')}"
+                )
+
+            migrated_content, replacement_count = (
+                LEGACY_DATA_INFO_HEADER_PATTERN.subn(
+                    replace_header,
+                    content,
+                    count=1,
+                )
+            )
+            if replacement_count != 1:
+                logger.warning(
+                    "Could not automatically migrate legacy [data_info] in %s: "
+                    "the section is not represented by a standalone TOML table "
+                    "header; keeping the compatibility fallback.",
+                    config_file,
+                )
+                return
+
+            cls._replace_config_text(target_file, migrated_content)
+            logger.info(
+                "Migrated legacy [data_info] to [DATA_INFO] in %s.",
+                config_file,
+            )
+        except FileNotFoundError:
+            return
+        except PermissionError as error:
+            logger.warning(
+                "Could not migrate legacy [data_info] to [DATA_INFO] in %s: "
+                "permission denied (%s). The legacy section remains supported.",
+                config_file,
+                error,
+            )
+        except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+            logger.warning(
+                "Could not migrate legacy [data_info] to [DATA_INFO] in %s: "
+                "the config file could not be parsed (%s).",
+                config_file,
+                error,
+            )
+        except OSError as error:
+            logger.warning(
+                "Could not migrate legacy [data_info] to [DATA_INFO] in %s: "
+                "filesystem error (%s). The legacy section remains supported.",
+                config_file,
+                error,
+            )
+        except Exception as error:
+            logger.warning(
+                "Could not migrate legacy [data_info] to [DATA_INFO] in %s: "
+                "unexpected error %s (%s). The legacy section remains supported.",
+                config_file,
+                type(error).__name__,
+                error,
+            )
+
+    @staticmethod
+    def _replace_config_text(config_file: Path, content: str) -> None:
+        """Atomically replace config text while preserving file permissions."""
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=config_file.parent,
+                prefix=f".{config_file.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temporary_file:
+                temporary_file.write(content.encode("utf-8"))
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
+                temporary_path = Path(temporary_file.name)
+
+            file_mode = stat.S_IMODE(config_file.stat().st_mode)
+            temporary_path.chmod(file_mode)
+            os.replace(temporary_path, config_file)
+        except Exception:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+            raise
 
     @cached_property
     def config(self) -> dict[str, Any]:

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -41,7 +41,8 @@ DATA_INFO_METRICS = (
 DEFAULT_DATA_INFO_METRICS = ("obs", "mean", "stderr", "min", "max")
 LEGACY_DATA_INFO_HEADER_PATTERN = re.compile(
     r"^(?P<indent>[ \t]*)"
-    r"\[(?P<quote>[\"']?)data_info(?P=quote)\]"
+    r"\[(?P<inner_leading>[ \t]*)(?P<quote>[\"']?)"
+    r"data_info(?P=quote)(?P<inner_trailing>[ \t]*)\]"
     r"(?P<suffix>[ \t]*(?:#[^\r\n]*)?)"
     r"(?P<carriage_return>\r?)$",
     re.MULTILINE,
@@ -238,7 +239,10 @@ class Config:
                 if match is not None:
                     quote = match.group("quote")
                     migrated_line_body = (
-                        f"{match.group('indent')}[{quote}DATA_INFO{quote}]"
+                        f"{match.group('indent')}["
+                        f"{match.group('inner_leading')}"
+                        f"{quote}DATA_INFO{quote}"
+                        f"{match.group('inner_trailing')}]"
                         f"{match.group('suffix')}"
                         f"{match.group('carriage_return')}"
                     )

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -363,7 +363,10 @@ class Config:
             value = self._first_environment_value(env_vars)
 
         if value is None:
-            value = self._first_config_value(self.config, config_paths)
+            for runtime_config in self._runtime_config_sources(config_paths):
+                value = self._first_config_value(runtime_config, config_paths)
+                if value is not None:
+                    break
 
         if value is None:
             return default
@@ -378,6 +381,29 @@ class Config:
             return default
 
         return value
+
+    def _runtime_config_sources(
+        self,
+        config_paths: list[list[str]],
+    ) -> tuple[dict[str, Any], ...]:
+        """Return runtime TOML sources in authority order.
+
+        Context specificity must only compare keys from the same source.
+        Otherwise a specific user key could incorrectly outrank a generic
+        project key. Security keeps its deliberate user-before-project order.
+        """
+        if self.is_debug_config:
+            return (self._read_toml_file(self.config_file),)
+
+        is_security_value = all(
+            config_path and config_path[0] == self.SECURITY_SECTION
+            for config_path in config_paths
+        )
+        user_config = self._read_toml_file(self.user_config_file)
+        project_config = self._read_toml_file(self.project_config_file)
+        if is_security_value:
+            return user_config, project_config
+        return project_config, user_config
 
     def _first_config_value(
         self,

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -318,10 +318,10 @@ class Config:
                 suffix=".tmp",
                 delete=False,
             ) as temporary_file:
+                temporary_path = Path(temporary_file.name)
                 temporary_file.write(content.encode("utf-8"))
                 temporary_file.flush()
                 os.fsync(temporary_file.fileno())
-                temporary_path = Path(temporary_file.name)
 
             if hasattr(os, "chown"):
                 temporary_stat = temporary_path.stat()

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -11,6 +11,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import stat
 import sys
 import tempfile
@@ -306,9 +307,10 @@ class Config:
 
     @staticmethod
     def _replace_config_text(config_file: Path, content: str) -> None:
-        """Atomically replace config text while preserving file permissions."""
+        """Atomically replace config text while preserving file metadata."""
         temporary_path: Path | None = None
         try:
+            original_stat = config_file.stat()
             with tempfile.NamedTemporaryFile(
                 mode="wb",
                 dir=config_file.parent,
@@ -321,8 +323,38 @@ class Config:
                 os.fsync(temporary_file.fileno())
                 temporary_path = Path(temporary_file.name)
 
-            file_mode = stat.S_IMODE(config_file.stat().st_mode)
-            temporary_path.chmod(file_mode)
+            if hasattr(os, "chown"):
+                temporary_stat = temporary_path.stat()
+                target_user_id = (
+                    original_stat.st_uid
+                    if temporary_stat.st_uid != original_stat.st_uid
+                    else -1
+                )
+                target_group_id = (
+                    original_stat.st_gid
+                    if temporary_stat.st_gid != original_stat.st_gid
+                    else -1
+                )
+                if target_user_id != -1 or target_group_id != -1:
+                    os.chown(
+                        temporary_path,
+                        target_user_id,
+                        target_group_id,
+                    )
+            shutil.copystat(config_file, temporary_path, follow_symlinks=True)
+
+            temporary_stat = temporary_path.stat()
+            if stat.S_IMODE(temporary_stat.st_mode) != stat.S_IMODE(
+                original_stat.st_mode
+            ):
+                raise OSError("temporary config file mode does not match the original")
+            if hasattr(os, "chown") and (
+                temporary_stat.st_uid != original_stat.st_uid
+                or temporary_stat.st_gid != original_stat.st_gid
+            ):
+                raise OSError(
+                    "temporary config file ownership does not match the original"
+                )
             os.replace(temporary_path, config_file)
         except Exception:
             if temporary_path is not None:

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -12,9 +12,10 @@ import os
 import platform
 import sys
 import tomllib
+from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import tomli_w
 
@@ -22,6 +23,41 @@ from .core.types import StataCLINotFoundError
 from .stata import StataFinder
 
 logger = logging.getLogger(__name__)
+
+ToolContext = Literal["api", "cli", "mcp"]
+DATA_INFO_METRICS = (
+    "obs",
+    "mean",
+    "stderr",
+    "min",
+    "max",
+    "med",
+    "q1",
+    "q3",
+    "skewness",
+    "kurtosis",
+)
+DEFAULT_DATA_INFO_METRICS = ("obs", "mean", "stderr", "min", "max")
+
+
+@dataclass(frozen=True)
+class HelpToolConfig:
+    """Resolved help settings for one invocation context."""
+
+    is_cache: bool
+    is_save: bool
+
+
+@dataclass(frozen=True)
+class DataInfoToolConfig:
+    """Resolved data-info settings for one invocation context."""
+
+    is_cache: bool
+    metrics: tuple[str, ...]
+    string_keep_number: int
+    decimal_places: int
+    hash_length: int
+    heads: int
 
 
 class StataMcpFolder:
@@ -178,7 +214,7 @@ class Config:
         return config_file.read_text(encoding="utf-8")
 
     def _get_raw_config_value(
-        self, config_data: dict[str, Any], config_keys: list
+        self, config_data: dict[str, Any], config_keys: list[str]
     ) -> Any | None:
         config_dict = config_data
         for key in config_keys[:-1]:
@@ -278,7 +314,12 @@ class Config:
         return value
 
     def _get_config_value(
-        self, config_keys: list, env_var: str, default, converter=None, validator=None
+        self,
+        config_keys: list[str],
+        env_var: str,
+        default,
+        converter=None,
+        validator=None,
     ):
         """
         Generic configuration reading method with priority: environment variable > toml config file > default value
@@ -293,37 +334,68 @@ class Config:
         Returns:
             Configuration value (processed by converter and validator)
         """
-        # 1. Read from system config first. Linux administrators can enforce values.
-        value = self._get_raw_config_value(
-            self._read_toml_file(self.system_config_file),
-            config_keys,
+        return self._get_config_value_from_paths(
+            config_paths=[config_keys],
+            env_vars=[env_var] if env_var else [],
+            default=default,
+            converter=converter,
+            validator=validator,
         )
 
-        # 2. Read from environment variable if system config does not enforce a value.
-        if value is None and env_var:
-            value = os.getenv(env_var, None)  # str | None
-        value = self._clean_string_value(value)
+    def _get_config_value_from_paths(
+        self,
+        config_paths: list[list[str]],
+        env_vars: list[str],
+        default,
+        converter=None,
+        validator=None,
+    ):
+        """Resolve ordered config paths without mixing source and specificity.
 
-        # 3. If no environment variable, read from config file
+        Source precedence is system configuration, environment, merged runtime
+        configuration, then the built-in default. Within each source, paths and
+        environment aliases are checked from most specific to least specific.
+        """
+        system_config = self._read_toml_file(self.system_config_file)
+        value = self._first_config_value(system_config, config_paths)
+
         if value is None:
-            value = self._get_raw_config_value(self.config, config_keys)
+            value = self._first_environment_value(env_vars)
 
-        # 4. If still no value, return default
+        if value is None:
+            value = self._first_config_value(self.config, config_paths)
+
         if value is None:
             return default
 
-        # 5. Convert value
         if converter is not None:
             try:
                 value = converter(value)
             except (ValueError, TypeError):
                 return default
 
-        # 6. Validate value
         if validator is not None and not validator(value):
             return default
 
         return value
+
+    def _first_config_value(
+        self,
+        config_data: dict[str, Any],
+        config_paths: list[list[str]],
+    ) -> Any | None:
+        for config_path in config_paths:
+            value = self._get_raw_config_value(config_data, config_path)
+            if value is not None:
+                return value
+        return None
+
+    def _first_environment_value(self, env_vars: list[str]) -> Any | None:
+        for env_var in env_vars:
+            value = self._clean_string_value(os.getenv(env_var))
+            if value is not None:
+                return value
+        return None
 
     @staticmethod
     def _to_bool(value):
@@ -363,6 +435,221 @@ class Config:
             raise TypeError("Expected a comma-separated string or string collection.")
         return tuple(str(item).strip() for item in values if str(item).strip())
 
+    @staticmethod
+    def _to_metrics(value) -> tuple[str, ...]:
+        metrics = Config._to_str_tuple(value)
+        normalized_metrics = tuple(metric.lower() for metric in metrics)
+        if not normalized_metrics:
+            raise ValueError("At least one data-info metric is required.")
+        if any(metric not in DATA_INFO_METRICS for metric in normalized_metrics):
+            raise ValueError("Unsupported data-info metric.")
+        return tuple(dict.fromkeys(normalized_metrics))
+
+    @staticmethod
+    def _normalize_tool_context(context: ToolContext | None) -> ToolContext:
+        normalized_context = "api" if context is None else str(context).lower()
+        if normalized_context not in {"api", "cli", "mcp"}:
+            raise ValueError(f"Unsupported tool context: {context}")
+        return normalized_context  # type: ignore[return-value]
+
+    @classmethod
+    def _tool_config_paths(
+        cls,
+        context: ToolContext | None,
+        tool_name: str,
+        key: str,
+        generic_sections: tuple[str, ...],
+    ) -> list[list[str]]:
+        normalized_context = cls._normalize_tool_context(context)
+        config_paths: list[list[str]] = []
+        if normalized_context in {"mcp", "cli"}:
+            config_paths.append(
+                [normalized_context.upper(), "TOOLS", tool_name.upper(), key]
+            )
+        config_paths.extend([[section, key] for section in generic_sections])
+        return config_paths
+
+    @classmethod
+    def _tool_environment_vars(
+        cls,
+        context: ToolContext | None,
+        tool_name: str,
+        key: str,
+        legacy_aliases: tuple[str, ...] = (),
+    ) -> list[str]:
+        normalized_context = cls._normalize_tool_context(context)
+        env_vars: list[str] = []
+        if normalized_context in {"mcp", "cli"}:
+            env_vars.append(
+                f"STATA_MCP__{normalized_context.upper()}__TOOLS__"
+                f"{tool_name.upper()}__{key.upper()}"
+            )
+        env_vars.append(f"STATA_MCP__{tool_name.upper()}__{key.upper()}")
+        env_vars.extend(legacy_aliases)
+        return env_vars
+
+    def _get_tool_config_value(
+        self,
+        *,
+        context: ToolContext | None,
+        tool_name: str,
+        key: str,
+        generic_sections: tuple[str, ...],
+        default,
+        converter=None,
+        validator=None,
+        legacy_env_vars: tuple[str, ...] = (),
+    ):
+        return self._get_config_value_from_paths(
+            config_paths=self._tool_config_paths(
+                context,
+                tool_name,
+                key,
+                generic_sections,
+            ),
+            env_vars=self._tool_environment_vars(
+                context,
+                tool_name,
+                key,
+                legacy_env_vars,
+            ),
+            default=default,
+            converter=converter,
+            validator=validator,
+        )
+
+    def get_help_config(self, context: ToolContext | None = None) -> HelpToolConfig:
+        """Return help settings with context-specific values before `[HELP]`."""
+        is_cache = self._get_tool_config_value(
+            context=context,
+            tool_name="HELP",
+            key="IS_CACHE",
+            generic_sections=("HELP",),
+            legacy_env_vars=("STATA_MCP__CACHE_HELP",),
+            default=True,
+            converter=self._to_bool,
+            validator=lambda value: isinstance(value, bool),
+        )
+        is_save = self._get_tool_config_value(
+            context=context,
+            tool_name="HELP",
+            key="IS_SAVE",
+            generic_sections=("HELP",),
+            legacy_env_vars=("STATA_MCP__SAVE_HELP",),
+            default=True,
+            converter=self._to_bool,
+            validator=lambda value: isinstance(value, bool),
+        )
+        return HelpToolConfig(is_cache=is_cache, is_save=is_save)
+
+    def get_data_info_config(
+        self,
+        context: ToolContext | None = None,
+    ) -> DataInfoToolConfig:
+        """Return validated data-info settings for API, CLI, or MCP usage."""
+        normalized_context = self._normalize_tool_context(context)
+        generic_sections = ("DATA_INFO", "data_info")
+        default_heads = 5 if normalized_context == "cli" else 0
+
+        is_cache = self._get_tool_config_value(
+            context=normalized_context,
+            tool_name="DATA_INFO",
+            key="is_cache",
+            generic_sections=generic_sections,
+            legacy_env_vars=(
+                "STATA_MCP__DATA_INFO_IS_CACHE",
+                "STATA_MCP_DATA_INFO_IS_CACHE",
+            ),
+            default=True,
+            converter=self._to_bool,
+            validator=lambda value: isinstance(value, bool),
+        )
+        metrics = self._get_tool_config_value(
+            context=normalized_context,
+            tool_name="DATA_INFO",
+            key="metrics",
+            generic_sections=generic_sections,
+            default=DEFAULT_DATA_INFO_METRICS,
+            converter=self._to_metrics,
+            validator=lambda value: isinstance(value, tuple),
+        )
+        string_keep_number = self._get_tool_config_value(
+            context=normalized_context,
+            tool_name="DATA_INFO",
+            key="string_keep_number",
+            generic_sections=generic_sections,
+            legacy_env_vars=("STATA_MCP_DATA_INFO_STRING_KEEP_NUMBER",),
+            default=10,
+            converter=self._to_int,
+            validator=lambda value: isinstance(value, int) and value >= 0,
+        )
+        decimal_places = self._get_tool_config_value(
+            context=normalized_context,
+            tool_name="DATA_INFO",
+            key="decimal_places",
+            generic_sections=generic_sections,
+            legacy_env_vars=("STATA_MCP_DATA_INFO_DECIMAL_PLACES",),
+            default=3,
+            converter=self._to_int,
+            validator=lambda value: isinstance(value, int) and value >= 0,
+        )
+        hash_length = self._get_tool_config_value(
+            context=normalized_context,
+            tool_name="DATA_INFO",
+            key="hash_length",
+            generic_sections=generic_sections,
+            legacy_env_vars=("STATA_MCP_DATA_INFO_HASH_LENGTH",),
+            default=12,
+            converter=self._to_int,
+            validator=lambda value: isinstance(value, int) and 1 <= value <= 32,
+        )
+        heads = self._get_tool_config_value(
+            context=normalized_context,
+            tool_name="DATA_INFO",
+            key="heads",
+            generic_sections=generic_sections,
+            default=default_heads,
+            converter=self._to_int,
+            validator=lambda value: isinstance(value, int),
+        )
+        return DataInfoToolConfig(
+            is_cache=is_cache,
+            metrics=metrics,
+            string_keep_number=string_keep_number,
+            decimal_places=decimal_places,
+            hash_length=hash_length,
+            heads=heads,
+        )
+
+    def is_tool_enabled(
+        self,
+        context: ToolContext,
+        tool_name: str,
+        *,
+        default: bool = True,
+    ) -> bool:
+        """Return a context tool switch without bypassing profile restrictions."""
+        normalized_context = self._normalize_tool_context(context)
+        if normalized_context == "api":
+            return default
+        normalized_tool_name = tool_name.upper()
+        return self._get_config_value_from_paths(
+            config_paths=[
+                [
+                    normalized_context.upper(),
+                    "TOOLS",
+                    f"ENABLE_{normalized_tool_name}",
+                ]
+            ],
+            env_vars=[
+                f"STATA_MCP__{normalized_context.upper()}__TOOLS__"
+                f"ENABLE_{normalized_tool_name}"
+            ],
+            default=default,
+            converter=self._to_bool,
+            validator=lambda value: isinstance(value, bool),
+        )
+
     @cached_property
     def ENABLE_DATA_INFO_URL_GUARD(self) -> bool:
         return self._get_config_value(
@@ -385,13 +672,7 @@ class Config:
 
     @cached_property
     def DATA_INFO_IS_CACHE(self) -> bool:
-        return self._get_config_value(
-            config_keys=["data_info", "is_cache"],
-            env_var="STATA_MCP__DATA_INFO_IS_CACHE",
-            default=True,
-            converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool),
-        )
+        return self.get_data_info_config("api").is_cache
 
     @cached_property
     def ENABLE_STRUCTURED_LOG(self) -> bool:
@@ -447,23 +728,11 @@ class Config:
 
     @property
     def IS_CACHE_HELP(self) -> bool:
-        return self._get_config_value(
-            config_keys=["HELP", "IS_CACHE"],
-            env_var="STATA_MCP__CACHE_HELP",
-            default=True,
-            converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool),
-        )
+        return self.get_help_config("api").is_cache
 
     @property
     def IS_SAVE_HELP(self) -> bool:
-        return self._get_config_value(
-            config_keys=["HELP", "IS_SAVE"],
-            env_var="STATA_MCP__SAVE_HELP",
-            default=True,
-            converter=self._to_bool,
-            validator=lambda x: isinstance(x, bool),
-        )
+        return self.get_help_config("api").is_save
 
     @property
     def LOGGING_ON(self) -> bool:
@@ -607,6 +876,24 @@ class Config:
             converter=self._to_bool,
             validator=lambda x: isinstance(x, bool),
         )
+
+    @cached_property
+    def ADDITIONAL_ALLOWED_DIRS(self) -> tuple[Path, ...]:
+        """Return additional security roots resolved against `WORKING_DIR`."""
+        configured_paths = self._get_config_value(
+            config_keys=["SECURITY", "ADDITIONAL_ALLOWED_DIRS"],
+            env_var="STATA_MCP__ADDITIONAL_ALLOWED_DIRS",
+            default=(),
+            converter=self._to_str_tuple,
+            validator=lambda value: isinstance(value, tuple),
+        )
+        resolved_paths = []
+        for configured_path in configured_paths:
+            path = Path(configured_path).expanduser()
+            if not path.is_absolute():
+                path = self.WORKING_DIR / path
+            resolved_paths.append(path.resolve())
+        return tuple(dict.fromkeys(resolved_paths))
 
     @property
     def IS_MONITOR(self) -> bool:

--- a/src/stata_mcp/data_info/base.py
+++ b/src/stata_mcp/data_info/base.py
@@ -207,12 +207,44 @@ class DataInfoBase(ABC):
         self.cache_dir = Path(cache_dir) if cache_dir else Path.home() / ".statamcp" / ".cache"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-        self.string_keep_number = (
-            int(string_keep_number) if string_keep_number is not None else 10
+        runtime_settings = None
+        if any(
+            value is None
+            for value in (
+                string_keep_number,
+                decimal_places,
+                hash_length,
+                metrics,
+            )
+        ):
+            runtime_settings = self._load_default_runtime_settings()
+
+        resolved_string_keep_number = (
+            string_keep_number
+            if string_keep_number is not None
+            else getattr(runtime_settings, "string_keep_number", 10)
         )
-        self.decimal_places = int(decimal_places) if decimal_places is not None else 3
-        self.HASH_LENGTH = int(hash_length) if hash_length is not None else 12
-        self._metrics = self._normalize_metrics(metrics)
+        resolved_decimal_places = (
+            decimal_places
+            if decimal_places is not None
+            else getattr(runtime_settings, "decimal_places", 3)
+        )
+        resolved_hash_length = (
+            hash_length
+            if hash_length is not None
+            else getattr(runtime_settings, "hash_length", 12)
+        )
+        resolved_metrics = (
+            metrics
+            if metrics is not None
+            else getattr(runtime_settings, "metrics", None)
+        )
+        self.string_keep_number = (
+            int(resolved_string_keep_number)
+        )
+        self.decimal_places = int(resolved_decimal_places)
+        self.HASH_LENGTH = int(resolved_hash_length)
+        self._metrics = self._normalize_metrics(resolved_metrics)
         self._head = head
         self._cache_read_options = repr(kwargs)
 
@@ -233,6 +265,20 @@ class DataInfoBase(ABC):
         ]
         unique_metrics = list(dict.fromkeys(normalized_metrics))
         return unique_metrics or list(cls.DEFAULT_METRICS)
+
+    @staticmethod
+    def _load_default_runtime_settings() -> Any | None:
+        """Resolve generic settings for callers that instantiate handlers directly."""
+        try:
+            from ..config import Config
+
+            return Config().get_data_info_config("api")
+        except Exception as error:
+            logger.warning(
+                "Could not resolve default data-info settings: %s",
+                error,
+            )
+            return None
 
     # Properties
     @cached_property

--- a/src/stata_mcp/data_info/base.py
+++ b/src/stata_mcp/data_info/base.py
@@ -11,9 +11,7 @@ import copy
 import hashlib
 import json
 import logging
-import os
 import time
-import tomllib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property
@@ -140,13 +138,12 @@ class DataInfoBase(ABC):
     # Registry of supported file extensions (to be overridden by subclasses)
     supported_extensions: List[str] = []
 
-    CFG_FILE = Path.home() / ".statamcp" / "config.toml"
     DEFAULT_METRICS: List[str] = [
         'obs', 'mean', 'stderr', 'min', 'max'
     ]
     ALLOWED_METRICS: List[str] = DEFAULT_METRICS + [
         # Additional metrics
-        'q1', 'q3', 'skewness', 'kurtosis'
+        'med', 'q1', 'q3', 'skewness', 'kurtosis'
     ]
 
     # Request timeout
@@ -176,6 +173,7 @@ class DataInfoBase(ABC):
         string_keep_number: int = None,
         decimal_places: int = None,
         hash_length: int = None,
+        metrics: List[str] | Tuple[str, ...] | None = None,
         head: int = 0,
         request_id: str | None = None,
         **kwargs
@@ -207,44 +205,31 @@ class DataInfoBase(ABC):
         self.cache_dir = Path(cache_dir) if cache_dir else Path.home() / ".statamcp" / ".cache"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-        self.string_keep_number = self._resolve_data_info_value(
-            string_keep_number, "STATA_MCP_DATA_INFO_STRING_KEEP_NUMBER", "string_keep_number", 10
+        self.string_keep_number = (
+            int(string_keep_number) if string_keep_number is not None else 10
         )
-        self.decimal_places = self._resolve_data_info_value(
-            decimal_places, "STATA_MCP_DATA_INFO_DECIMAL_PLACES", "decimal_places", 3
-        )
-        self.HASH_LENGTH = self._resolve_data_info_value(
-            hash_length, "STATA_MCP_DATA_INFO_HASH_LENGTH", "hash_length", 12
-        )
+        self.decimal_places = int(decimal_places) if decimal_places is not None else 3
+        self.HASH_LENGTH = int(hash_length) if hash_length is not None else 12
+        self._metrics = self._normalize_metrics(metrics)
         self._head = head
 
         self.kwargs = kwargs  # Store additional keyword arguments for subclasses to use
 
-    def _resolve_data_info_value(
-        self,
-        explicit_value: int | None,
-        env_var: str,
-        config_key: str,
-        default: int,
-    ) -> int:
-        """Resolve a data_info config value with explicit > env > config > default priority."""
-        if explicit_value is not None:
-            return int(explicit_value)
-
-        env_value = os.getenv(env_var, None)
-        if env_value is not None:
-            return int(env_value)
-
-        try:
-            with open(self.CFG_FILE, "rb") as f:
-                config = tomllib.load(f)
-            config_value = config.get("data_info", {}).get(config_key, None)
-            if config_value is not None:
-                return int(config_value)
-        except (FileNotFoundError, OSError, Exception):
-            pass
-
-        return default
+    @classmethod
+    def _normalize_metrics(
+        cls,
+        metrics: List[str] | Tuple[str, ...] | None,
+    ) -> List[str]:
+        """Return supported metrics in caller order, or the legacy defaults."""
+        if metrics is None:
+            return list(cls.DEFAULT_METRICS)
+        normalized_metrics = [
+            str(metric).lower()
+            for metric in metrics
+            if str(metric).lower() in cls.ALLOWED_METRICS
+        ]
+        unique_metrics = list(dict.fromkeys(normalized_metrics))
+        return unique_metrics or list(cls.DEFAULT_METRICS)
 
     # Properties
     @cached_property
@@ -327,22 +312,7 @@ class DataInfoBase(ABC):
 
     @property
     def metrics(self) -> List[str]:
-        try:
-            with open(self.CFG_FILE, "rb") as f:
-                config = tomllib.load(f)
-
-            additional = config.get("data_info", {}).get("metrics", []) or []
-            if not isinstance(additional, list):
-                additional = [additional]
-
-            target = (set(self.DEFAULT_METRICS) | set(additional)) & set(self.ALLOWED_METRICS)
-
-            return list(dict.fromkeys(
-                [m for m in self.DEFAULT_METRICS if m in target] +
-                [m for m in self.ALLOWED_METRICS if m in target]
-            ))
-        except (FileNotFoundError, OSError, Exception):
-            return self.DEFAULT_METRICS
+        return list(self._metrics)
 
     @property
     def df(self) -> pd.DataFrame:

--- a/src/stata_mcp/data_info/base.py
+++ b/src/stata_mcp/data_info/base.py
@@ -25,6 +25,11 @@ import numpy as np
 import pandas as pd
 import requests
 
+from .._data_info_metrics import (
+    DATA_INFO_METRICS,
+    DEFAULT_DATA_INFO_METRICS,
+    normalize_data_info_metrics,
+)
 from .._diagnostic_logging import (
     elapsed_ms,
     log_event,
@@ -140,13 +145,8 @@ class DataInfoBase(ABC):
     CACHE_SCHEMA_VERSION = 2
     CACHE_SETTINGS_HASH_LENGTH = 16
 
-    DEFAULT_METRICS: List[str] = [
-        'obs', 'mean', 'stderr', 'min', 'max'
-    ]
-    ALLOWED_METRICS: List[str] = DEFAULT_METRICS + [
-        # Additional metrics
-        'med', 'q1', 'q3', 'skewness', 'kurtosis'
-    ]
+    DEFAULT_METRICS: List[str] = list(DEFAULT_DATA_INFO_METRICS)
+    ALLOWED_METRICS: List[str] = list(DATA_INFO_METRICS)
 
     # Request timeout
     DEFAULT_TIMEOUT = (5, 30)
@@ -255,16 +255,8 @@ class DataInfoBase(ABC):
         cls,
         metrics: List[str] | Tuple[str, ...] | None,
     ) -> List[str]:
-        """Return supported metrics in caller order, or the legacy defaults."""
-        if metrics is None:
-            return list(cls.DEFAULT_METRICS)
-        normalized_metrics = [
-            str(metric).lower()
-            for metric in metrics
-            if str(metric).lower() in cls.ALLOWED_METRICS
-        ]
-        unique_metrics = list(dict.fromkeys(normalized_metrics))
-        return unique_metrics or list(cls.DEFAULT_METRICS)
+        """Keep mandatory metrics and append supported extras."""
+        return list(normalize_data_info_metrics(metrics))
 
     @staticmethod
     def _load_default_runtime_settings() -> Any | None:

--- a/src/stata_mcp/data_info/base.py
+++ b/src/stata_mcp/data_info/base.py
@@ -137,6 +137,8 @@ class DataInfoBase(ABC):
 
     # Registry of supported file extensions (to be overridden by subclasses)
     supported_extensions: List[str] = []
+    CACHE_SCHEMA_VERSION = 2
+    CACHE_SETTINGS_HASH_LENGTH = 16
 
     DEFAULT_METRICS: List[str] = [
         'obs', 'mean', 'stderr', 'min', 'max'
@@ -212,6 +214,7 @@ class DataInfoBase(ABC):
         self.HASH_LENGTH = int(hash_length) if hash_length is not None else 12
         self._metrics = self._normalize_metrics(metrics)
         self._head = head
+        self._cache_read_options = repr(kwargs)
 
         self.kwargs = kwargs  # Store additional keyword arguments for subclasses to use
 
@@ -308,7 +311,38 @@ class DataInfoBase(ABC):
 
     @property
     def cached_file(self) -> Path:
-        return self.cache_dir / f"data_info__{self.name}_{self.suffix.strip('.')}__hash_{self.hash[:self.HASH_LENGTH]}.json"
+        return self.cache_dir / (
+            f"data_info__{self.name}_{self.suffix.strip('.')}__"
+            f"hash_{self.hash[: self.HASH_LENGTH]}__"
+            f"settings_{self.cache_settings_hash}.json"
+        )
+
+    @cached_property
+    def cache_settings_hash(self) -> str:
+        """Return a stable identity for settings that can change cached output."""
+        source_identity = (
+            str(self.data_path) if self.is_url else self.data_path.resolve().as_posix()
+        )
+        cache_settings = {
+            "schema_version": self.CACHE_SCHEMA_VERSION,
+            "handler": f"{type(self).__module__}.{type(self).__qualname__}",
+            "source": source_identity,
+            "encoding": self.encoding,
+            "read_options": self._cache_read_options,
+            "metrics": self.metrics,
+            "string_keep_number": self.string_keep_number,
+            "decimal_places": self.decimal_places,
+            "hash_length": self.HASH_LENGTH,
+        }
+        serialized_settings = json.dumps(
+            cache_settings,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return hashlib.sha256(serialized_settings.encode("utf-8")).hexdigest()[
+            : self.CACHE_SETTINGS_HASH_LENGTH
+        ]
 
     @property
     def metrics(self) -> List[str]:

--- a/src/stata_mcp/guard/data_path_auditor.py
+++ b/src/stata_mcp/guard/data_path_auditor.py
@@ -35,6 +35,7 @@ class DataPathAuditor:
         strict_local_boundary: bool,
         enable_url_guard: bool,
         allowed_url_domains: tuple[str, ...],
+        additional_allowed_dirs: tuple[Path, ...] = (),
     ) -> None:
         """Initialize the auditor.
 
@@ -45,11 +46,14 @@ class DataPathAuditor:
             enable_url_guard: When True, enforce HTTPS, host, and allowlist
                 restrictions on URLs.
             allowed_url_domains: Domains permitted when URL guard is enabled.
+            additional_allowed_dirs: Extra roots accepted by strict local
+                boundary checks.
         """
         self.working_dir = working_dir
         self.strict_local_boundary = strict_local_boundary
         self.enable_url_guard = enable_url_guard
         self.allowed_url_domains = allowed_url_domains
+        self.additional_allowed_dirs = additional_allowed_dirs
 
     @staticmethod
     def is_url(data_path: str) -> bool:
@@ -119,15 +123,17 @@ class DataPathAuditor:
         if not candidate_path.is_absolute():
             candidate_path = self.working_dir / candidate_path
         resolved_data_path = candidate_path.resolve()
-        resolved_working_dir = self.working_dir.resolve()
-        try:
-            resolved_data_path.relative_to(resolved_working_dir)
-        except ValueError:
-            logging.warning(
-                "[SECURITY VIOLATION] Attempted to access data file outside working directory."
-            )
-            return LOCAL_ACCESS_DENIED
-        return resolved_data_path
+        allowed_dirs = (self.working_dir, *self.additional_allowed_dirs)
+        for allowed_dir in allowed_dirs:
+            try:
+                resolved_data_path.relative_to(allowed_dir.resolve())
+                return resolved_data_path
+            except ValueError:
+                continue
+        logging.warning(
+            "[SECURITY VIOLATION] Attempted to access data file outside allowed directories."
+        )
+        return LOCAL_ACCESS_DENIED
 
     def validate_url(self, data_path: str) -> tuple[str, str] | str:
         """Validate a URL.

--- a/src/stata_mcp/guard/validator.py
+++ b/src/stata_mcp/guard/validator.py
@@ -280,6 +280,11 @@ class GuardValidator:
                 strict_local_boundary=config.STRICT_DATA_INFO_LOCAL_BOUNDARY,
                 enable_url_guard=config.ENABLE_DATA_INFO_URL_GUARD,
                 allowed_url_domains=config.DATA_INFO_ALLOWED_URL_DOMAINS,
+                additional_allowed_dirs=getattr(
+                    config,
+                    "ADDITIONAL_ALLOWED_DIRS",
+                    (),
+                ),
             )
 
         for line_num, line in executable_lines:

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -135,11 +135,14 @@ def _load_help_cls():
     if _help_cls is None:
         from .stata import StataHelp
 
+        help_config = config.get_help_config("mcp")
         _help_cls = StataHelp(
             stata_cli=config.STATA_CLI,
             project_tmp_dir=config.STATA_MCP_FOLDER.TMP,
             cache_dir=config.HELP_CACHE_DIR,
             config=config,
+            is_cache=help_config.is_cache,
+            is_save=help_config.is_save,
         )
 
     return _help_cls
@@ -550,7 +553,7 @@ def get_data_info(
     data_path: str,
     vars_list: List[str] | None = None,
     encoding: str = "utf-8",
-    head: int = 0,
+    head: int | None = None,
     ctx: Context | None = None,
 ) -> str:
     """
@@ -637,6 +640,7 @@ def get_data_info(
             encoding=encoding,
             config_file=None,
             head=head,
+            tool_context="mcp",
             request_id=request_id,
         )
         log_event(
@@ -807,6 +811,7 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "or execute a do-file. "
         ),
         "func": stata_do,
+        "config_name": "STATA_DO",
         "profiles": {"core", "all"},
     },
     "get_data_info": {
@@ -817,6 +822,7 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "Use when you need to understand a dataset or have no prior knowledge of the data."
         ),
         "func": get_data_info,
+        "config_name": "DATA_INFO",
         "profiles": {"core", "all"},
     },
     "help": {
@@ -826,6 +832,7 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "or troubleshoot errors before running it."
         ),
         "func": help,
+        "config_name": "HELP",
         "profiles": {"core", "all"},
         "unix_only": True,
     },
@@ -836,6 +843,7 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "Use `lines` to return only the first/last N lines."
         ),
         "func": read_log,
+        "config_name": "READ_LOG",
         "profiles": {"all"},
     },
     "ado_package_install": {
@@ -845,6 +853,7 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
             "per-call user confirmation."
         ),
         "func": ado_package_install,
+        "config_name": "ADO_INSTALL",
         "profiles": {"unsafe"},
     },
 }
@@ -872,6 +881,12 @@ def register_tools(server: FastMCP, profile: str = "all") -> None:
             continue
         eligible_profiles = {"all", "unsafe"} if profile == "unsafe" else {profile}
         if not eligible_profiles.intersection(meta["profiles"]):
+            continue
+        is_tool_enabled = getattr(config, "is_tool_enabled", None)
+        if callable(is_tool_enabled) and not is_tool_enabled(
+            "mcp",
+            meta.get("config_name", name),
+        ):
             continue
 
         tool_func: ToolFunc | None = meta.get("func")

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -186,6 +186,7 @@ def _prepare_stata_do_request(dofile_path: str) -> Dict[str, Any] | _StataDoRequ
     candidate_allowed_dirs = [
         config.STATA_MCP_FOLDER.DO,
         config.WORKING_DIR,
+        *getattr(config, "ADDITIONAL_ALLOWED_DIRS", ()),
     ]
     allowed_dirs: List[Path] = []
     for candidate_dir in candidate_allowed_dirs:
@@ -727,9 +728,14 @@ def read_log(
     path = Path(file_path).resolve()  # Resolve to handle symlinks and ..
 
     # Security check: ensure the file is within the allowed directory
-    try:
-        path.relative_to(config.STATA_MCP_FOLDER.path.resolve())
-    except ValueError:
+    allowed_dirs = [
+        config.STATA_MCP_FOLDER.path.resolve(),
+        *(
+            allowed_dir.resolve()
+            for allowed_dir in getattr(config, "ADDITIONAL_ALLOWED_DIRS", ())
+        ),
+    ]
+    if not _is_within_allowed_directories(path, allowed_dirs):
         # Log security violation for audit purposes.
         # If this security warning appears, it may indicate that the current model has been compromised/poisoned.
         logging.warning(

--- a/src/stata_mcp/stata/builtin_tools/help/stata_help.py
+++ b/src/stata_mcp/stata/builtin_tools/help/stata_help.py
@@ -27,8 +27,12 @@ class StataHelp:
         project_tmp_dir: Path | None = None,
         cache_dir: Path | None = None,
         config: "Config | None" = None,
+        is_cache: bool | None = None,
+        is_save: bool | None = None,
     ):
         self._config = config
+        self._is_cache = is_cache
+        self._is_save = is_save
         self.help_cache_dir = cache_dir or (
             config.HELP_CACHE_DIR if config else Path.home() / ".statamcp" / "help"
         )
@@ -40,12 +44,18 @@ class StataHelp:
 
     @property
     def IS_SAVE(self) -> bool:
+        explicit_is_save = getattr(self, "_is_save", None)
+        if explicit_is_save is not None:
+            return explicit_is_save
         if self._config:
             return self._config.IS_SAVE_HELP
         return True
 
     @property
     def IS_CACHE(self) -> bool:
+        explicit_is_cache = getattr(self, "_is_cache", None)
+        if explicit_is_cache is not None:
+            return explicit_is_cache
         if self._config:
             return self._config.IS_CACHE_HELP
         return False

--- a/tests/api/test_read_log_security.py
+++ b/tests/api/test_read_log_security.py
@@ -4,8 +4,19 @@ from pathlib import Path
 from stata_mcp.api.read_log import read_log
 
 
-def _write_config(tmp_path: Path, working_dir: Path, *, strict_boundary: bool, enable_structured_log: bool = False) -> Path:
+def _write_config(
+    tmp_path: Path,
+    working_dir: Path,
+    *,
+    strict_boundary: bool,
+    enable_structured_log: bool = False,
+    additional_allowed_dirs: list[Path] | None = None,
+) -> Path:
     config_path = tmp_path / "config.toml"
+    additional_allowed_dirs = additional_allowed_dirs or []
+    allowed_dirs = ", ".join(
+        f'"{allowed_dir.as_posix()}"' for allowed_dir in additional_allowed_dirs
+    )
     config_path.write_text(
         "\n".join(
             [
@@ -14,6 +25,7 @@ def _write_config(tmp_path: Path, working_dir: Path, *, strict_boundary: bool, e
                 "",
                 "[SECURITY]",
                 f"strict_read_log_boundary = {str(strict_boundary).lower()}",
+                f"ADDITIONAL_ALLOWED_DIRS = [{allowed_dirs}]",
                 "",
                 "[BETA]",
                 f"enable_structured_log = {str(enable_structured_log).lower()}",
@@ -60,6 +72,25 @@ def test_strict_true_denies_file_outside_working_dir(tmp_path: Path) -> None:
     result = read_log(outside_file.as_posix(), config_file=config_path)
 
     assert result == "Access denied: log file must be within the stata-mcp folder."
+
+
+def test_strict_true_allows_file_in_additional_allowed_dir(tmp_path: Path) -> None:
+    working_dir = tmp_path / "work"
+    shared_dir = tmp_path / "shared"
+    working_dir.mkdir()
+    shared_dir.mkdir()
+    log_file = shared_dir / "test.log"
+    log_file.write_text("log content", encoding="utf-8")
+    config_path = _write_config(
+        tmp_path,
+        working_dir,
+        strict_boundary=True,
+        additional_allowed_dirs=[shared_dir],
+    )
+
+    result = read_log(log_file.as_posix(), config_file=config_path)
+
+    assert result == "log content"
 
 
 def test_strict_true_denies_parent_directory_escape(tmp_path: Path) -> None:

--- a/tests/cli/test_server_registration.py
+++ b/tests/cli/test_server_registration.py
@@ -163,6 +163,59 @@ def test_stata_do_tool_is_async_function_when_async_do_enabled(
     assert mcp_servers._TOOL_REGISTRY["stata_do"]["func"] is mcp_servers.stata_do
 
 
+def test_mcp_data_info_passes_mcp_context_when_head_is_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_modules,
+):
+    mcp_servers, _ = loaded_modules
+    get_data_info_module = importlib.import_module("stata_mcp.api.get_data_info")
+    calls = {}
+
+    def fake_get_data_info_impl(**kwargs):
+        calls.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(
+        get_data_info_module,
+        "_get_data_info_impl",
+        fake_get_data_info_impl,
+    )
+
+    assert mcp_servers.get_data_info("sample.csv") == "ok"
+    assert calls["tool_context"] == "mcp"
+    assert calls["head"] is None
+
+
+def test_mcp_help_uses_contextual_cache_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_modules,
+):
+    mcp_servers, _ = loaded_modules
+    stata_module = importlib.import_module("stata_mcp.stata")
+    captured_kwargs = {}
+    help_settings = SimpleNamespace(is_cache=False, is_save=True)
+    fake_config = SimpleNamespace(
+        IS_UNIX=True,
+        STATA_CLI="stata",
+        STATA_MCP_FOLDER=SimpleNamespace(TMP=Path("/tmp/project")),
+        HELP_CACHE_DIR=Path("/tmp/cache"),
+        get_help_config=lambda context: help_settings,
+    )
+
+    class _FakeStataHelp:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(mcp_servers, "config", fake_config)
+    monkeypatch.setattr(mcp_servers, "_help_cls", None)
+    monkeypatch.setattr(stata_module, "StataHelp", _FakeStataHelp)
+
+    mcp_servers._load_help_cls()
+
+    assert captured_kwargs["is_cache"] is False
+    assert captured_kwargs["is_save"] is True
+
+
 def test_register_tools_all_applies_platform_and_deprecated_filters(
     monkeypatch: pytest.MonkeyPatch,
     loaded_modules,
@@ -175,6 +228,44 @@ def test_register_tools_all_applies_platform_and_deprecated_filters(
 
     assert set(server.tools) == {"stata_do", "get_data_info", "read_log"}
     assert server.resources == []
+
+
+def test_register_tools_applies_config_switch_after_profile_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_modules,
+):
+    mcp_servers, _ = loaded_modules
+    _set_registry(monkeypatch, mcp_servers, unix=True)
+    monkeypatch.setattr(
+        mcp_servers.config,
+        "is_tool_enabled",
+        lambda context, tool_name: tool_name.upper() != "HELP",
+        raising=False,
+    )
+    server = _DummyServer()
+
+    mcp_servers.register_tools(server, profile="core")
+
+    assert set(server.tools) == {"stata_do", "get_data_info"}
+
+
+def test_tool_switch_cannot_add_tool_excluded_by_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_modules,
+):
+    mcp_servers, _ = loaded_modules
+    _set_registry(monkeypatch, mcp_servers, unix=True)
+    monkeypatch.setattr(
+        mcp_servers.config,
+        "is_tool_enabled",
+        lambda context, tool_name: True,
+        raising=False,
+    )
+    server = _DummyServer()
+
+    mcp_servers.register_tools(server, profile="all")
+
+    assert "ado_package_install" not in server.tools
 
 
 def test_register_tools_unsafe_includes_standard_and_high_risk_tools(

--- a/tests/cli/test_tool_config.py
+++ b/tests/cli/test_tool_config.py
@@ -1,0 +1,149 @@
+"""Tests for CLI tool configuration plumbing."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from stata_mcp.api import get_data_info as api_get_data_info
+from stata_mcp.cli._handlers import handle_tool
+from stata_mcp.cli._parsers import add_tool_parser, create_root_parser
+
+
+def _tool_parser():
+    parser = create_root_parser()
+    subparsers = parser.add_subparsers(dest="command")
+    add_tool_parser(subparsers)
+    return parser
+
+
+def test_data_info_heads_parser_distinguishes_omitted_and_explicit_values() -> None:
+    parser = _tool_parser()
+
+    omitted_args = parser.parse_args(["tool", "data-info", "sample.csv"])
+    positive_args = parser.parse_args(
+        ["tool", "data-info", "sample.csv", "--heads", "8"]
+    )
+    disabled_args = parser.parse_args(
+        ["tool", "data-info", "sample.csv", "--heads", "0"]
+    )
+    tail_args = parser.parse_args(
+        ["tool", "data-info", "sample.csv", "--heads", "-3"]
+    )
+
+    assert omitted_args.heads is None
+    assert positive_args.heads == 8
+    assert disabled_args.heads == 0
+    assert tail_args.heads == -3
+
+
+def test_data_info_handler_forwards_cli_context_and_omitted_head(
+    monkeypatch,
+) -> None:
+    get_data_info = Mock(return_value="data info")
+    fake_api = SimpleNamespace(
+        ado_package_install=Mock(),
+        get_data_info=get_data_info,
+        read_log=Mock(),
+        stata_do=Mock(),
+        stata_help=Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "stata_mcp.api", fake_api)
+    args = Namespace(
+        tool_action="data-info",
+        data_path="sample.csv",
+        vars_list=None,
+        encoding="utf-8",
+        heads=None,
+    )
+
+    assert handle_tool(args) == 0
+    get_data_info.assert_called_once_with(
+        data_path="sample.csv",
+        vars_list=None,
+        encoding="utf-8",
+        head=None,
+        tool_context="cli",
+    )
+
+
+def test_data_info_handler_forwards_explicit_heads(monkeypatch) -> None:
+    get_data_info = Mock(return_value="data info")
+    fake_api = SimpleNamespace(
+        ado_package_install=Mock(),
+        get_data_info=get_data_info,
+        read_log=Mock(),
+        stata_do=Mock(),
+        stata_help=Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "stata_mcp.api", fake_api)
+    args = Namespace(
+        tool_action="data-info",
+        data_path="sample.csv",
+        vars_list=["price"],
+        encoding="utf-8",
+        heads=0,
+    )
+
+    assert handle_tool(args) == 0
+    assert get_data_info.call_args.kwargs["head"] == 0
+    assert get_data_info.call_args.kwargs["tool_context"] == "cli"
+
+
+@pytest.mark.parametrize(
+    ("tool_config", "expected_heads"),
+    [
+        ("", 5),
+        ("\n[data_info]\nheads = 2", 2),
+        (
+            "\n[data_info]\nheads = 2\n\n"
+            "[CLI.TOOLS.DATA_INFO]\nheads = 7",
+            7,
+        ),
+    ],
+)
+def test_cli_api_resolves_heads_from_context_then_generic_then_default(
+    monkeypatch,
+    tmp_path: Path,
+    tool_config: str,
+    expected_heads: int,
+) -> None:
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    data_path = working_dir / "sample.csv"
+    data_path.write_text("x\n1\n", encoding="utf-8")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f'[PROJECT]\nWORKING_DIR = "{working_dir.as_posix()}"{tool_config}',
+        encoding="utf-8",
+    )
+    calls = []
+
+    class _FakeDataInfo:
+        def __init__(self, *args, **kwargs):
+            calls.append(kwargs)
+
+        @property
+        def info(self):
+            return {"ok": True}
+
+    get_data_info_module = importlib.import_module("stata_mcp.api.get_data_info")
+    monkeypatch.setattr(
+        get_data_info_module,
+        "get_data_handler",
+        lambda extension: _FakeDataInfo,
+    )
+
+    api_get_data_info(
+        data_path.as_posix(),
+        config_file=config_path,
+        tool_context="cli",
+    )
+
+    assert calls[-1]["head"] == expected_heads

--- a/tests/data_info/test_base.py
+++ b/tests/data_info/test_base.py
@@ -75,9 +75,16 @@ class TestFileValidation:
 class TestRuntimeSettings:
     """Test settings passed into a concrete data-info handler."""
 
-    def test_explicit_settings_replace_internal_config_reads(self, tmp_path):
+    def test_explicit_settings_replace_internal_config_reads(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
         from stata_mcp.data_info.csv import CsvDataInfo
 
+        monkeypatch.setenv("STATA_MCP_DATA_INFO_STRING_KEEP_NUMBER", "9")
+        monkeypatch.setenv("STATA_MCP_DATA_INFO_DECIMAL_PLACES", "8")
+        monkeypatch.setenv("STATA_MCP_DATA_INFO_HASH_LENGTH", "24")
         data_path = tmp_path / "sample.csv"
         data_path.write_text("value,label\n1,a\n2,b\n", encoding="utf-8")
 
@@ -95,6 +102,59 @@ class TestRuntimeSettings:
         assert data_info.string_keep_number == 2
         assert data_info.decimal_places == 1
         assert data_info.HASH_LENGTH == 6
+
+    def test_legacy_environment_settings_apply_to_direct_handler(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        from stata_mcp.data_info.csv import CsvDataInfo
+
+        monkeypatch.setenv("STATA_MCP_DATA_INFO_STRING_KEEP_NUMBER", "4")
+        monkeypatch.setenv("STATA_MCP_DATA_INFO_DECIMAL_PLACES", "1")
+        monkeypatch.setenv("STATA_MCP_DATA_INFO_HASH_LENGTH", "6")
+        data_path = tmp_path / "sample.csv"
+        data_path.write_text("value,label\n1,a\n2,b\n", encoding="utf-8")
+
+        data_info = CsvDataInfo(data_path)
+
+        assert data_info.string_keep_number == 4
+        assert data_info.decimal_places == 1
+        assert data_info.HASH_LENGTH == 6
+
+    def test_user_toml_settings_apply_to_direct_handler(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        from stata_mcp.data_info.csv import CsvDataInfo
+
+        home_dir = tmp_path / "home"
+        config_dir = home_dir / ".statamcp"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").write_text(
+            "\n".join(
+                [
+                    "[DATA_INFO]",
+                    'metrics = ["obs", "med"]',
+                    "string_keep_number = 3",
+                    "decimal_places = 2",
+                    "hash_length = 8",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: home_dir)
+        monkeypatch.chdir(tmp_path)
+        data_path = tmp_path / "sample.csv"
+        data_path.write_text("value,label\n1,a\n2,b\n", encoding="utf-8")
+
+        data_info = CsvDataInfo(data_path)
+
+        assert data_info.metrics == ["obs", "med"]
+        assert data_info.string_keep_number == 3
+        assert data_info.decimal_places == 2
+        assert data_info.HASH_LENGTH == 8
 
     def test_invalid_direct_metrics_fall_back_to_legacy_defaults(self, tmp_path):
         from stata_mcp.data_info.csv import CsvDataInfo

--- a/tests/data_info/test_base.py
+++ b/tests/data_info/test_base.py
@@ -72,6 +72,41 @@ class TestFileValidation:
             CsvDataInfo([])  # type: ignore
 
 
+class TestRuntimeSettings:
+    """Test settings passed into a concrete data-info handler."""
+
+    def test_explicit_settings_replace_internal_config_reads(self, tmp_path):
+        from stata_mcp.data_info.csv import CsvDataInfo
+
+        data_path = tmp_path / "sample.csv"
+        data_path.write_text("value,label\n1,a\n2,b\n", encoding="utf-8")
+
+        data_info = CsvDataInfo(
+            data_path,
+            is_cache=False,
+            metrics=["med", "q1", "med"],
+            string_keep_number=2,
+            decimal_places=1,
+            hash_length=6,
+        )
+
+        assert data_info.is_cache is False
+        assert data_info.metrics == ["med", "q1"]
+        assert data_info.string_keep_number == 2
+        assert data_info.decimal_places == 1
+        assert data_info.HASH_LENGTH == 6
+
+    def test_invalid_direct_metrics_fall_back_to_legacy_defaults(self, tmp_path):
+        from stata_mcp.data_info.csv import CsvDataInfo
+
+        data_path = tmp_path / "sample.csv"
+        data_path.write_text("value\n1\n", encoding="utf-8")
+
+        data_info = CsvDataInfo(data_path, metrics=["unsupported"])
+
+        assert data_info.metrics == DataInfoBase.DEFAULT_METRICS
+
+
 class TestDetermineVariableType:
     """测试 _determine_variable_type 静态方法"""
 

--- a/tests/data_info/test_base.py
+++ b/tests/data_info/test_base.py
@@ -98,7 +98,15 @@ class TestRuntimeSettings:
         )
 
         assert data_info.is_cache is False
-        assert data_info.metrics == ["med", "q1"]
+        assert data_info.metrics == [
+            "obs",
+            "mean",
+            "stderr",
+            "min",
+            "max",
+            "med",
+            "q1",
+        ]
         assert data_info.string_keep_number == 2
         assert data_info.decimal_places == 1
         assert data_info.HASH_LENGTH == 6
@@ -136,7 +144,7 @@ class TestRuntimeSettings:
             "\n".join(
                 [
                     "[DATA_INFO]",
-                    'metrics = ["obs", "med"]',
+                    'metrics = ["med"]',
                     "string_keep_number = 3",
                     "decimal_places = 2",
                     "hash_length = 8",
@@ -151,7 +159,14 @@ class TestRuntimeSettings:
 
         data_info = CsvDataInfo(data_path)
 
-        assert data_info.metrics == ["obs", "med"]
+        assert data_info.metrics == [
+            "obs",
+            "mean",
+            "stderr",
+            "min",
+            "max",
+            "med",
+        ]
         assert data_info.string_keep_number == 3
         assert data_info.decimal_places == 2
         assert data_info.HASH_LENGTH == 8
@@ -166,6 +181,39 @@ class TestRuntimeSettings:
 
         assert data_info.metrics == DataInfoBase.DEFAULT_METRICS
 
+    def test_direct_metrics_keep_defaults_and_ignore_unsupported_values(
+        self,
+        tmp_path,
+    ):
+        from stata_mcp.data_info.csv import CsvDataInfo
+
+        data_path = tmp_path / "sample.csv"
+        data_path.write_text("value\n1\n2\n", encoding="utf-8")
+
+        data_info = CsvDataInfo(
+            data_path,
+            metrics=["Q1", "unsupported", "q1", "mean", "MED"],
+        )
+
+        assert data_info.metrics == [
+            "obs",
+            "mean",
+            "stderr",
+            "min",
+            "max",
+            "q1",
+            "med",
+        ]
+        assert set(data_info.info["vars_detail"]["value"]["summary"]) == {
+            "obs",
+            "mean",
+            "stderr",
+            "min",
+            "max",
+            "q1",
+            "med",
+        }
+
     def test_cache_is_isolated_by_output_settings(self, tmp_path):
         from stata_mcp.data_info.csv import CsvDataInfo
 
@@ -178,21 +226,21 @@ class TestRuntimeSettings:
         first_handler = CsvDataInfo(
             data_path,
             cache_dir=cache_dir,
-            metrics=["mean"],
+            metrics=["q1"],
             string_keep_number=1,
             decimal_places=1,
         )
         second_handler = CsvDataInfo(
             data_path,
             cache_dir=cache_dir,
-            metrics=["mean"],
+            metrics=["q1"],
             string_keep_number=2,
             decimal_places=4,
         )
         different_metrics_handler = CsvDataInfo(
             data_path,
             cache_dir=cache_dir,
-            metrics=["max"],
+            metrics=["q3"],
             string_keep_number=2,
             decimal_places=4,
         )

--- a/tests/data_info/test_base.py
+++ b/tests/data_info/test_base.py
@@ -106,6 +106,51 @@ class TestRuntimeSettings:
 
         assert data_info.metrics == DataInfoBase.DEFAULT_METRICS
 
+    def test_cache_is_isolated_by_output_settings(self, tmp_path):
+        from stata_mcp.data_info.csv import CsvDataInfo
+
+        data_path = tmp_path / "sample.csv"
+        cache_dir = tmp_path / "cache"
+        data_path.write_text(
+            "value,label\n1.1234,alpha\n2.2345,beta\n",
+            encoding="utf-8",
+        )
+        first_handler = CsvDataInfo(
+            data_path,
+            cache_dir=cache_dir,
+            metrics=["mean"],
+            string_keep_number=1,
+            decimal_places=1,
+        )
+        second_handler = CsvDataInfo(
+            data_path,
+            cache_dir=cache_dir,
+            metrics=["mean"],
+            string_keep_number=2,
+            decimal_places=4,
+        )
+        different_metrics_handler = CsvDataInfo(
+            data_path,
+            cache_dir=cache_dir,
+            metrics=["max"],
+            string_keep_number=2,
+            decimal_places=4,
+        )
+
+        first_result = first_handler.info
+        second_result = second_handler.info
+
+        assert first_handler.cached_file != second_handler.cached_file
+        assert second_handler.cached_file != different_metrics_handler.cached_file
+        assert first_result["vars_detail"]["value"]["summary"]["mean"] == 1.7
+        assert second_result["vars_detail"]["value"]["summary"]["mean"] == 1.6789
+        assert second_result["vars_detail"]["label"]["summary"]["value_list"] == [
+            "alpha",
+            "beta",
+        ]
+        assert second_result["info_config"]["decimal_places"] == 4
+        assert len(list(cache_dir.glob("*.json"))) == 2
+
 
 class TestDetermineVariableType:
     """测试 _determine_variable_type 静态方法"""

--- a/tests/data_info/test_security.py
+++ b/tests/data_info/test_security.py
@@ -159,7 +159,7 @@ heads = 2
 
 [MCP.TOOLS.DATA_INFO]
 is_cache = false
-metrics = ["obs", "med"]
+metrics = ["med"]
 string_keep_number = 4
 decimal_places = 1
 hash_length = 8
@@ -175,7 +175,14 @@ heads = 7
     )
 
     assert fake_data_info.calls[-1]["is_cache"] is False
-    assert fake_data_info.calls[-1]["metrics"] == ("obs", "med")
+    assert fake_data_info.calls[-1]["metrics"] == (
+        "obs",
+        "mean",
+        "stderr",
+        "min",
+        "max",
+        "med",
+    )
     assert fake_data_info.calls[-1]["string_keep_number"] == 4
     assert fake_data_info.calls[-1]["decimal_places"] == 1
     assert fake_data_info.calls[-1]["hash_length"] == 8

--- a/tests/data_info/test_security.py
+++ b/tests/data_info/test_security.py
@@ -51,6 +51,10 @@ class _FakeDataInfo:
         cache_dir=None,
         head: int = 0,
         is_cache: bool = True,
+        metrics=None,
+        string_keep_number: int = 10,
+        decimal_places: int = 3,
+        hash_length: int = 12,
         request_id: str | None = None,
     ):
         self.data_path = data_path
@@ -59,6 +63,10 @@ class _FakeDataInfo:
         self.cache_dir = cache_dir
         self.head = head
         self.is_cache = is_cache
+        self.metrics = metrics
+        self.string_keep_number = string_keep_number
+        self.decimal_places = decimal_places
+        self.hash_length = hash_length
         self.request_id = request_id
         self.calls.append(
             {
@@ -68,6 +76,10 @@ class _FakeDataInfo:
                 "cache_dir": cache_dir,
                 "head": head,
                 "is_cache": is_cache,
+                "metrics": metrics,
+                "string_keep_number": string_keep_number,
+                "decimal_places": decimal_places,
+                "hash_length": hash_length,
                 "request_id": request_id,
             }
         )
@@ -117,6 +129,77 @@ def test_local_file_within_working_dir_is_allowed(tmp_path) -> None:
 
     payload = json.loads(result)
     assert payload["overview"]["source"] == data_path.resolve().as_posix()
+
+
+def test_contextual_data_info_settings_are_passed_to_handler(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    fake_data_info = _patch_fake_data_info(monkeypatch)
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    data_path = working_dir / "data.csv"
+    data_path.write_text("x,y\n1,2\n", encoding="utf-8")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[PROJECT]
+WORKING_DIR = "{working_dir.as_posix()}"
+
+[data_info]
+heads = 2
+
+[MCP.TOOLS.DATA_INFO]
+is_cache = false
+metrics = ["obs", "med"]
+string_keep_number = 4
+decimal_places = 1
+hash_length = 8
+heads = 7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    api_get_data_info(
+        data_path=data_path.as_posix(),
+        config_file=config_path,
+        tool_context="mcp",
+    )
+
+    assert fake_data_info.calls[-1]["is_cache"] is False
+    assert fake_data_info.calls[-1]["metrics"] == ("obs", "med")
+    assert fake_data_info.calls[-1]["string_keep_number"] == 4
+    assert fake_data_info.calls[-1]["decimal_places"] == 1
+    assert fake_data_info.calls[-1]["hash_length"] == 8
+    assert fake_data_info.calls[-1]["head"] == 7
+
+
+def test_explicit_head_overrides_contextual_default(monkeypatch, tmp_path) -> None:
+    fake_data_info = _patch_fake_data_info(monkeypatch)
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    data_path = working_dir / "data.csv"
+    data_path.write_text("x,y\n1,2\n", encoding="utf-8")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+[PROJECT]
+WORKING_DIR = "{working_dir.as_posix()}"
+
+[MCP.TOOLS.DATA_INFO]
+heads = 7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    api_get_data_info(
+        data_path=data_path.as_posix(),
+        config_file=config_path,
+        head=0,
+        tool_context="mcp",
+    )
+
+    assert fake_data_info.calls[-1]["head"] == 0
 
 
 def test_local_file_outside_working_dir_is_allowed_by_default(tmp_path) -> None:

--- a/tests/data_info/test_security.py
+++ b/tests/data_info/test_security.py
@@ -14,6 +14,7 @@ def _write_config(
     enable_guard: bool | None = None,
     allowed_domains: list[str] | None = None,
     strict_local_boundary: bool | None = None,
+    additional_allowed_dirs: list[Path] | None = None,
 ) -> Path:
     config_path = tmp_path / "config.toml"
     lines = [
@@ -28,12 +29,19 @@ def _write_config(
         if allowed_domains is not None:
             domains = ", ".join(f'"{domain}"' for domain in allowed_domains)
             lines.append(f"data_info_allowed_url_domains = [{domains}]")
-    if strict_local_boundary is not None:
+    if strict_local_boundary is not None or additional_allowed_dirs is not None:
         lines.append("")
         lines.append("[SECURITY]")
-        lines.append(
-            f"strict_data_info_local_boundary = {str(strict_local_boundary).lower()}"
-        )
+        if strict_local_boundary is not None:
+            lines.append(
+                f"strict_data_info_local_boundary = {str(strict_local_boundary).lower()}"
+            )
+        if additional_allowed_dirs is not None:
+            allowed_dirs = ", ".join(
+                f'"{allowed_dir.as_posix()}"'
+                for allowed_dir in additional_allowed_dirs
+            )
+            lines.append(f"ADDITIONAL_ALLOWED_DIRS = [{allowed_dirs}]")
 
     config_path.write_text("\n".join(lines), encoding="utf-8")
     return config_path
@@ -218,6 +226,32 @@ def test_local_file_outside_working_dir_is_allowed_by_default(tmp_path) -> None:
 
     payload = json.loads(result)
     assert payload["overview"]["source"] == data_path.resolve().as_posix()
+
+
+def test_local_file_in_additional_allowed_dir_is_allowed_when_strict(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    fake_data_info = _patch_fake_data_info(monkeypatch)
+    working_dir = tmp_path / "work"
+    shared_dir = tmp_path / "shared"
+    working_dir.mkdir()
+    shared_dir.mkdir()
+    data_path = shared_dir / "data.csv"
+    data_path.write_text("x,y\n1,2\n", encoding="utf-8")
+    config_path = _write_config(
+        tmp_path,
+        working_dir,
+        strict_local_boundary=True,
+        additional_allowed_dirs=[shared_dir],
+    )
+
+    api_get_data_info(
+        data_path=data_path.as_posix(),
+        config_file=config_path,
+    )
+
+    assert fake_data_info.calls[-1]["data_path"] == data_path.resolve()
 
 
 def test_local_file_outside_working_dir_is_rejected_when_boundary_is_enabled(

--- a/tests/guard/test_data_path_auditor.py
+++ b/tests/guard/test_data_path_auditor.py
@@ -55,6 +55,52 @@ def test_local_file_outside_working_dir_is_rejected(
     assert result == LOCAL_ACCESS_DENIED
 
 
+def test_local_file_within_additional_allowed_dir_is_allowed(
+    working_dir: Path,
+    tmp_path: Path,
+) -> None:
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    data_file = shared_dir / "data.csv"
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+    shared_auditor = DataPathAuditor(
+        working_dir=working_dir,
+        strict_local_boundary=True,
+        enable_url_guard=False,
+        allowed_url_domains=(),
+        additional_allowed_dirs=(shared_dir,),
+    )
+
+    result = shared_auditor.validate_local_path(data_file.as_posix())
+
+    assert result == data_file.resolve()
+
+
+def test_symlink_in_additional_dir_cannot_escape_allowed_roots(
+    working_dir: Path,
+    tmp_path: Path,
+) -> None:
+    shared_dir = tmp_path / "shared"
+    outside_dir = tmp_path / "outside"
+    shared_dir.mkdir()
+    outside_dir.mkdir()
+    outside_file = outside_dir / "secret.csv"
+    outside_file.write_text("secret\n1\n", encoding="utf-8")
+    symlink_file = shared_dir / "linked.csv"
+    symlink_file.symlink_to(outside_file)
+    shared_auditor = DataPathAuditor(
+        working_dir=working_dir,
+        strict_local_boundary=True,
+        enable_url_guard=False,
+        allowed_url_domains=(),
+        additional_allowed_dirs=(shared_dir,),
+    )
+
+    result = shared_auditor.validate_local_path(symlink_file.as_posix())
+
+    assert result == LOCAL_ACCESS_DENIED
+
+
 def test_relative_local_file_resolved_from_working_dir(
     auditor: DataPathAuditor, working_dir: Path
 ) -> None:

--- a/tests/guard/test_validator_data_commands.py
+++ b/tests/guard/test_validator_data_commands.py
@@ -50,6 +50,22 @@ def test_data_command_with_safe_local_path_passes(
     assert report.is_safe is True
 
 
+def test_data_command_with_additional_allowed_path_passes(
+    enabled_config,
+    tmp_path: Path,
+) -> None:
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    data_file = shared_dir / "data.dta"
+    data_file.write_bytes(b"data")
+    enabled_config.ADDITIONAL_ALLOWED_DIRS = (shared_dir,)
+    code = f'use "{data_file.as_posix()}"'
+
+    report = GuardValidator().validate(code, config=enabled_config)
+
+    assert report.is_safe is True
+
+
 def test_data_command_with_prefixes_is_detected(
     enabled_config, working_dir: Path
 ) -> None:

--- a/tests/stata/test_do_boundary.py
+++ b/tests/stata/test_do_boundary.py
@@ -554,6 +554,31 @@ def test_stata_do_allows_dofile_in_do_directory(
     assert result["log_file_path"]["text"] == log_file.as_posix()
 
 
+def test_mcp_stata_do_allows_dofile_in_additional_allowed_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_mcp_servers,
+    tmp_path: Path,
+):
+    do_dir = tmp_path / "do"
+    work_dir = tmp_path / "work"
+    shared_dir = tmp_path / "shared"
+    do_dir.mkdir()
+    work_dir.mkdir()
+    shared_dir.mkdir()
+    dofile = shared_dir / "ok.do"
+    dofile.write_text("display 1")
+    log_file = tmp_path / "run.log"
+    log_file.write_text("ok")
+    _configure_base(monkeypatch, loaded_mcp_servers, do_dir, work_dir, tmp_path)
+    loaded_mcp_servers.config.ADDITIONAL_ALLOWED_DIRS = (shared_dir,)
+    _patch_stata_module(monkeypatch, log_file)
+
+    result = loaded_mcp_servers.stata_do(dofile.as_posix())
+
+    assert "error" not in result
+    assert result["log_file_path"]["text"] == log_file.as_posix()
+
+
 def test_stata_do_rejects_when_allowed_directories_are_empty(
     monkeypatch: pytest.MonkeyPatch, loaded_mcp_servers, tmp_path: Path
 ):
@@ -651,6 +676,49 @@ def test_api_stata_do_rejects_package_management_when_guard_is_disabled(
 
     assert result["action"] == "Security check, dofile not executed"
     stata_executor.assert_not_called()
+
+
+def test_api_stata_do_allows_dofile_in_additional_allowed_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    stata_do_api = importlib.import_module("stata_mcp.api.stata_do")
+    do_dir = tmp_path / "do"
+    work_dir = tmp_path / "work"
+    shared_dir = tmp_path / "shared"
+    do_dir.mkdir()
+    work_dir.mkdir()
+    shared_dir.mkdir()
+    dofile = shared_dir / "allowed.do"
+    dofile.write_text("display 1")
+    log_file = tmp_path / "run.log"
+    log_file.write_text("ok")
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(
+            STATA_MCP_FOLDER=SimpleNamespace(DO=do_dir),
+            WORKING_DIR=work_dir,
+            ADDITIONAL_ALLOWED_DIRS=(shared_dir,),
+            IS_GUARD=False,
+            IS_MONITOR=False,
+        ),
+        stata_cli="stata",
+        log_base_path=tmp_path,
+        is_unix=True,
+        cwd=work_dir,
+    )
+    stata_executor = Mock()
+    stata_executor.execute_dofile.return_value = {"text": log_file}
+    monkeypatch.setattr(
+        stata_do_api,
+        "create_runtime_context",
+        lambda **kwargs: runtime,
+    )
+    monkeypatch.setattr(stata_do_api, "StataDo", Mock(return_value=stata_executor))
+
+    result = stata_do_api.stata_do(dofile.as_posix())
+
+    assert "error" not in result
+    assert result["log_file_path"]["text"] == log_file.as_posix()
 
 
 class TestApiStataDoSecurityLog:

--- a/tests/stata/test_help_interfaces.py
+++ b/tests/stata/test_help_interfaces.py
@@ -16,16 +16,24 @@ stata_help_api = importlib.import_module("stata_mcp.api.stata_help")
 
 def test_api_forwards_replace_to_help_reader(monkeypatch: pytest.MonkeyPatch) -> None:
     help_reader = Mock()
+    help_config = SimpleNamespace(is_cache=False, is_save=True)
     runtime = SimpleNamespace(
         stata_cli="stata",
         tmp_base_path="/tmp/project",
-        config=SimpleNamespace(HELP_CACHE_DIR="/tmp/cache"),
+        config=SimpleNamespace(
+            HELP_CACHE_DIR="/tmp/cache",
+            get_help_config=Mock(return_value=help_config),
+        ),
     )
     monkeypatch.setattr(stata_help_api, "create_runtime_context", lambda **kwargs: runtime)
-    monkeypatch.setattr(stata_help_api, "StataHelp", lambda **kwargs: help_reader)
+    help_factory = Mock(return_value=help_reader)
+    monkeypatch.setattr(stata_help_api, "StataHelp", help_factory)
 
-    stata_help_api.stata_help("regress", replace=True)
+    stata_help_api.stata_help("regress", replace=True, tool_context="cli")
 
+    runtime.config.get_help_config.assert_called_once_with("cli")
+    assert help_factory.call_args.kwargs["is_cache"] is False
+    assert help_factory.call_args.kwargs["is_save"] is True
     help_reader.help.assert_called_once_with("regress", replace=True)
 
 
@@ -68,4 +76,8 @@ def test_cli_help_handler_forwards_replace(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     assert handle_tool(args) == 0
-    stata_help.assert_called_once_with(cmd="regress", replace=True)
+    stata_help.assert_called_once_with(
+        cmd="regress",
+        replace=True,
+        tool_context="cli",
+    )

--- a/tests/stata/test_help_interfaces.py
+++ b/tests/stata/test_help_interfaces.py
@@ -9,6 +9,7 @@ import pytest
 
 from stata_mcp.cli._handlers import handle_tool
 from stata_mcp.cli._parsers import add_tool_parser, create_root_parser
+from stata_mcp.stata import StataHelp
 
 stata_help_api = importlib.import_module("stata_mcp.api.stata_help")
 
@@ -26,6 +27,16 @@ def test_api_forwards_replace_to_help_reader(monkeypatch: pytest.MonkeyPatch) ->
     stata_help_api.stata_help("regress", replace=True)
 
     help_reader.help.assert_called_once_with("regress", replace=True)
+
+
+def test_explicit_help_settings_override_generic_config() -> None:
+    help_reader = StataHelp.__new__(StataHelp)
+    help_reader._config = SimpleNamespace(IS_CACHE_HELP=False, IS_SAVE_HELP=False)
+    help_reader._is_cache = True
+    help_reader._is_save = True
+
+    assert help_reader.IS_CACHE is True
+    assert help_reader.IS_SAVE is True
 
 
 def test_cli_help_parser_exposes_replace_flag() -> None:

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,0 +1,187 @@
+"""Tests for automatic data-info table-name migration."""
+
+from __future__ import annotations
+
+import logging
+import stat
+from pathlib import Path
+
+import pytest
+
+from stata_mcp.config import Config
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    config_file = tmp_path / "config.toml"
+    config_file.write_bytes(content.encode("utf-8"))
+    return config_file
+
+
+def test_legacy_data_info_header_is_renamed_without_reformatting(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    original_content = (
+        "# Keep this comment and formatting.\r\n"
+        "[data_info] # legacy table\r\n"
+        "is_cache = false\r\n"
+        "metrics = [\"obs\", \"med\"]\r\n"
+    )
+    config_file = _write_config(tmp_path, original_content)
+    config_file.chmod(0o640)
+
+    with caplog.at_level(logging.INFO):
+        config = Config(config_file=config_file)
+
+    migrated_content = config_file.read_bytes().decode("utf-8")
+    assert migrated_content == original_content.replace(
+        "[data_info]",
+        "[DATA_INFO]",
+        1,
+    )
+    assert stat.S_IMODE(config_file.stat().st_mode) == 0o640
+    assert config.get_data_info_config("api").is_cache is False
+    assert config.get_data_info_config("api").metrics == ("obs", "med")
+    assert "Migrated legacy [data_info] to [DATA_INFO]" in caplog.text
+
+
+def test_quoted_legacy_header_is_renamed(tmp_path: Path) -> None:
+    config_file = _write_config(
+        tmp_path,
+        '["data_info"]\nis_cache = false\n',
+    )
+
+    Config(config_file=config_file)
+
+    assert '["DATA_INFO"]' in config_file.read_text(encoding="utf-8")
+
+
+def test_existing_uppercase_and_lowercase_sections_are_not_overwritten(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    original_content = """
+[data_info]
+is_cache = false
+hash_length = 8
+
+[DATA_INFO]
+hash_length = 16
+""".strip()
+    config_file = _write_config(tmp_path, original_content)
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert config_file.read_text(encoding="utf-8") == original_content
+    assert config.get_data_info_config("api").is_cache is False
+    assert config.get_data_info_config("api").hash_length == 16
+    assert "both [data_info] and [DATA_INFO] exist" in caplog.text
+
+
+def test_permission_failure_is_logged_and_legacy_config_still_works(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        "[data_info]\nis_cache = false\n",
+    )
+
+    def deny_write(config_file: Path, content: str) -> None:
+        raise PermissionError("read-only config")
+
+    monkeypatch.setattr(Config, "_replace_config_text", staticmethod(deny_write))
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert "[data_info]" in config_file.read_text(encoding="utf-8")
+    assert config.get_data_info_config("api").is_cache is False
+    assert "permission denied" in caplog.text
+    assert "read-only config" in caplog.text
+
+
+def test_other_filesystem_failure_is_logged_and_does_not_stop_loading(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        "[data_info]\ndecimal_places = 2\n",
+    )
+
+    def fail_write(config_file: Path, content: str) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(Config, "_replace_config_text", staticmethod(fail_write))
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert config.get_data_info_config("api").decimal_places == 2
+    assert "filesystem error" in caplog.text
+    assert "read-only file system" in caplog.text
+
+
+def test_unexpected_write_failure_is_logged_and_does_not_stop_loading(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        "[data_info]\nhash_length = 8\n",
+    )
+
+    def fail_write(config_file: Path, content: str) -> None:
+        raise RuntimeError("unexpected storage adapter failure")
+
+    monkeypatch.setattr(Config, "_replace_config_text", staticmethod(fail_write))
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert config.get_data_info_config("api").hash_length == 8
+    assert "unexpected error RuntimeError" in caplog.text
+    assert "unexpected storage adapter failure" in caplog.text
+
+
+def test_inline_legacy_table_logs_safe_fallback(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    original_content = "data_info = { is_cache = false }\n"
+    config_file = _write_config(tmp_path, original_content)
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert config_file.read_text(encoding="utf-8") == original_content
+    assert config.get_data_info_config("api").is_cache is False
+    assert "not represented by a standalone TOML table header" in caplog.text
+
+
+def test_uppercase_only_config_does_not_attempt_a_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        "[DATA_INFO]\nis_cache = false\n",
+    )
+
+    def unexpected_write(config_file: Path, content: str) -> None:
+        raise AssertionError("uppercase config must not be rewritten")
+
+    monkeypatch.setattr(
+        Config,
+        "_replace_config_text",
+        staticmethod(unexpected_write),
+    )
+
+    config = Config(config_file=config_file)
+
+    assert config.get_data_info_config("api").is_cache is False

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -43,6 +45,60 @@ def test_legacy_data_info_header_is_renamed_without_reformatting(
     assert config.get_data_info_config("api").is_cache is False
     assert config.get_data_info_config("api").metrics == ("obs", "med")
     assert "Migrated legacy [data_info] to [DATA_INFO]" in caplog.text
+
+
+@pytest.mark.skipif(not hasattr(os, "chown"), reason="Ownership is not POSIX metadata")
+def test_legacy_header_migration_reapplies_owner_and_group(
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        "[data_info]\nis_cache = false\n",
+    )
+    current_group_id = config_file.stat().st_gid
+    target_group_id = next(
+        (group_id for group_id in os.getgroups() if group_id != current_group_id),
+        None,
+    )
+    if target_group_id is None:
+        pytest.skip("No secondary group is available for an ownership test")
+    try:
+        os.chown(config_file, -1, target_group_id)
+    except OSError as error:
+        pytest.skip(f"Could not assign a secondary test group: {error}")
+    original_stat = config_file.stat()
+
+    Config(config_file=config_file)
+
+    migrated_stat = config_file.stat()
+    assert migrated_stat.st_uid == original_stat.st_uid
+    assert migrated_stat.st_gid == original_stat.st_gid
+
+
+@pytest.mark.skipif(
+    not all(hasattr(os, name) for name in ("setxattr", "getxattr")),
+    reason="Extended attributes are not supported",
+)
+def test_legacy_header_migration_preserves_extended_attributes(
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        "[data_info]\nis_cache = false\n",
+    )
+    attribute_name = (
+        "com.stata_mcp.test"
+        if sys.platform == "darwin"
+        else "user.stata_mcp_test"
+    )
+    try:
+        os.setxattr(config_file, attribute_name, b"preserve-me")
+    except OSError as error:
+        pytest.skip(f"Filesystem does not support test extended attributes: {error}")
+
+    Config(config_file=config_file)
+
+    assert os.getxattr(config_file, attribute_name) == b"preserve-me"
 
 
 def test_quoted_legacy_header_is_renamed(tmp_path: Path) -> None:
@@ -128,6 +184,32 @@ def test_permission_failure_is_logged_and_legacy_config_still_works(
     assert config.get_data_info_config("api").is_cache is False
     assert "permission denied" in caplog.text
     assert "read-only config" in caplog.text
+
+
+def test_metadata_copy_failure_is_logged_and_original_file_is_kept(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    original_content = "[data_info]\nis_cache = false\n"
+    config_file = _write_config(tmp_path, original_content)
+
+    def deny_metadata_copy(*args, **kwargs) -> None:
+        raise PermissionError("metadata is protected")
+
+    monkeypatch.setattr(
+        "stata_mcp.config.shutil.copystat",
+        deny_metadata_copy,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert config_file.read_text(encoding="utf-8") == original_content
+    assert config.get_data_info_config("api").is_cache is False
+    assert "permission denied" in caplog.text
+    assert "metadata is protected" in caplog.text
+    assert list(tmp_path.glob(".config.toml.*.tmp")) == []
 
 
 def test_other_filesystem_failure_is_logged_and_does_not_stop_loading(

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -25,7 +25,7 @@ def test_legacy_data_info_header_is_renamed_without_reformatting(
         "# Keep this comment and formatting.\r\n"
         "[data_info] # legacy table\r\n"
         "is_cache = false\r\n"
-        "metrics = [\"obs\", \"med\"]\r\n"
+        'metrics = ["obs", "med"]\r\n'
     )
     config_file = _write_config(tmp_path, original_content)
     config_file.chmod(0o640)
@@ -54,6 +54,33 @@ def test_quoted_legacy_header_is_renamed(tmp_path: Path) -> None:
     Config(config_file=config_file)
 
     assert '["DATA_INFO"]' in config_file.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("delimiter", ['"""', "'''"])
+def test_legacy_header_migration_ignores_multiline_string_content(
+    delimiter: str,
+    tmp_path: Path,
+) -> None:
+    original_content = (
+        f"note = {delimiter}\n"
+        "[data_info]\n"
+        "This is documentation, not a table header.\n"
+        f"{delimiter}\n"
+        "\n"
+        "[data_info]\n"
+        "is_cache = false\n"
+    )
+    config_file = _write_config(tmp_path, original_content)
+
+    config = Config(config_file=config_file)
+
+    migrated_content = config_file.read_text(encoding="utf-8")
+    assert migrated_content == original_content.replace(
+        "\n[data_info]\nis_cache",
+        "\n[DATA_INFO]\nis_cache",
+        1,
+    )
+    assert config.get_data_info_config("api").is_cache is False
 
 
 def test_existing_uppercase_and_lowercase_sections_are_not_overwritten(

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -212,6 +212,29 @@ def test_metadata_copy_failure_is_logged_and_original_file_is_kept(
     assert list(tmp_path.glob(".config.toml.*.tmp")) == []
 
 
+def test_fsync_failure_removes_temporary_file_and_keeps_original(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    original_content = "[data_info]\nis_cache = false\n"
+    config_file = _write_config(tmp_path, original_content)
+
+    def fail_fsync(file_descriptor: int) -> None:
+        raise OSError("disk flush failed")
+
+    monkeypatch.setattr("stata_mcp.config.os.fsync", fail_fsync)
+
+    with caplog.at_level(logging.WARNING):
+        config = Config(config_file=config_file)
+
+    assert config_file.read_text(encoding="utf-8") == original_content
+    assert config.get_data_info_config("api").is_cache is False
+    assert "filesystem error" in caplog.text
+    assert "disk flush failed" in caplog.text
+    assert list(tmp_path.glob(".config.toml.*.tmp")) == []
+
+
 def test_other_filesystem_failure_is_logged_and_does_not_stop_loading(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -31,6 +31,7 @@ def test_legacy_data_info_header_is_renamed_without_reformatting(
     )
     config_file = _write_config(tmp_path, original_content)
     config_file.chmod(0o640)
+    original_inode = config_file.stat().st_ino
 
     with caplog.at_level(logging.INFO):
         config = Config(config_file=config_file)
@@ -42,6 +43,7 @@ def test_legacy_data_info_header_is_renamed_without_reformatting(
         1,
     )
     assert stat.S_IMODE(config_file.stat().st_mode) == 0o640
+    assert config_file.stat().st_ino == original_inode
     assert config.get_data_info_config("api").is_cache is False
     assert config.get_data_info_config("api").metrics == ("obs", "med")
     assert "Migrated legacy [data_info] to [DATA_INFO]" in caplog.text
@@ -71,6 +73,7 @@ def test_legacy_header_migration_reapplies_owner_and_group(
     Config(config_file=config_file)
 
     migrated_stat = config_file.stat()
+    assert migrated_stat.st_ino == original_stat.st_ino
     assert migrated_stat.st_uid == original_stat.st_uid
     assert migrated_stat.st_gid == original_stat.st_gid
 
@@ -172,7 +175,7 @@ def test_permission_failure_is_logged_and_legacy_config_still_works(
         "[data_info]\nis_cache = false\n",
     )
 
-    def deny_write(config_file: Path, content: str) -> None:
+    def deny_write(config_file: Path, content: str, **kwargs) -> None:
         raise PermissionError("read-only config")
 
     monkeypatch.setattr(Config, "_replace_config_text", staticmethod(deny_write))
@@ -186,33 +189,25 @@ def test_permission_failure_is_logged_and_legacy_config_still_works(
     assert "read-only config" in caplog.text
 
 
-def test_metadata_copy_failure_is_logged_and_original_file_is_kept(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+def test_concurrent_config_change_is_not_overwritten(
     tmp_path: Path,
 ) -> None:
     original_content = "[data_info]\nis_cache = false\n"
     config_file = _write_config(tmp_path, original_content)
+    external_content = original_content + "# edited by another process\n"
+    config_file.write_text(external_content, encoding="utf-8")
 
-    def deny_metadata_copy(*args, **kwargs) -> None:
-        raise PermissionError("metadata is protected")
+    with pytest.raises(OSError, match="changed while migration"):
+        Config._replace_config_text(
+            config_file,
+            original_content.replace("[data_info]", "[DATA_INFO]"),
+            expected_content=original_content,
+        )
 
-    monkeypatch.setattr(
-        "stata_mcp.config.shutil.copystat",
-        deny_metadata_copy,
-    )
-
-    with caplog.at_level(logging.WARNING):
-        config = Config(config_file=config_file)
-
-    assert config_file.read_text(encoding="utf-8") == original_content
-    assert config.get_data_info_config("api").is_cache is False
-    assert "permission denied" in caplog.text
-    assert "metadata is protected" in caplog.text
-    assert list(tmp_path.glob(".config.toml.*.tmp")) == []
+    assert config_file.read_text(encoding="utf-8") == external_content
 
 
-def test_fsync_failure_removes_temporary_file_and_keeps_original(
+def test_fsync_failure_rolls_back_in_place_and_keeps_original(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -245,7 +240,7 @@ def test_other_filesystem_failure_is_logged_and_does_not_stop_loading(
         "[data_info]\ndecimal_places = 2\n",
     )
 
-    def fail_write(config_file: Path, content: str) -> None:
+    def fail_write(config_file: Path, content: str, **kwargs) -> None:
         raise OSError("read-only file system")
 
     monkeypatch.setattr(Config, "_replace_config_text", staticmethod(fail_write))
@@ -268,7 +263,7 @@ def test_unexpected_write_failure_is_logged_and_does_not_stop_loading(
         "[data_info]\nhash_length = 8\n",
     )
 
-    def fail_write(config_file: Path, content: str) -> None:
+    def fail_write(config_file: Path, content: str, **kwargs) -> None:
         raise RuntimeError("unexpected storage adapter failure")
 
     monkeypatch.setattr(Config, "_replace_config_text", staticmethod(fail_write))

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -27,7 +27,7 @@ def test_legacy_data_info_header_is_renamed_without_reformatting(
         "# Keep this comment and formatting.\r\n"
         "[data_info] # legacy table\r\n"
         "is_cache = false\r\n"
-        'metrics = ["obs", "med"]\r\n'
+        'metrics = ["med", "unknown", "med"]\r\n'
     )
     config_file = _write_config(tmp_path, original_content)
     config_file.chmod(0o640)
@@ -45,7 +45,14 @@ def test_legacy_data_info_header_is_renamed_without_reformatting(
     assert stat.S_IMODE(config_file.stat().st_mode) == 0o640
     assert config_file.stat().st_ino == original_inode
     assert config.get_data_info_config("api").is_cache is False
-    assert config.get_data_info_config("api").metrics == ("obs", "med")
+    assert config.get_data_info_config("api").metrics == (
+        "obs",
+        "mean",
+        "stderr",
+        "min",
+        "max",
+        "med",
+    )
     assert "Migrated legacy [data_info] to [DATA_INFO]" in caplog.text
 
 

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -115,6 +115,29 @@ def test_quoted_legacy_header_is_renamed(tmp_path: Path) -> None:
     assert '["DATA_INFO"]' in config_file.read_text(encoding="utf-8")
 
 
+@pytest.mark.parametrize(
+    ("legacy_header", "canonical_header"),
+    [
+        ("[ data_info ]", "[ DATA_INFO ]"),
+        ("[ 'data_info' ] # keep", "[ 'DATA_INFO' ] # keep"),
+    ],
+)
+def test_legacy_header_with_inner_whitespace_is_renamed(
+    legacy_header: str,
+    canonical_header: str,
+    tmp_path: Path,
+) -> None:
+    config_file = _write_config(
+        tmp_path,
+        f"{legacy_header}\nis_cache = false\n",
+    )
+
+    config = Config(config_file=config_file)
+
+    assert canonical_header in config_file.read_text(encoding="utf-8")
+    assert config.get_data_info_config("api").is_cache is False
+
+
 @pytest.mark.parametrize("delimiter", ['"""', "'''"])
 def test_legacy_header_migration_ignores_multiline_string_content(
     delimiter: str,

--- a/tests/test_config_tool_context.py
+++ b/tests/test_config_tool_context.py
@@ -161,7 +161,7 @@ decimal_places = 4
 
 [MCP.TOOLS.DATA_INFO]
 is_cache = true
-metrics = ["obs", "med", "q1"]
+metrics = ["med", "unsupported", "q1", "med"]
 hash_length = 16
 """,
     )
@@ -169,7 +169,7 @@ hash_length = 16
     settings = Config(config_file=config_path).get_data_info_config("mcp")
 
     assert settings.is_cache is True
-    assert settings.metrics == ("obs", "med", "q1")
+    assert settings.metrics == DEFAULT_DATA_INFO_METRICS + ("med", "q1")
     assert settings.string_keep_number == 7
     assert settings.decimal_places == 4
     assert settings.hash_length == 16
@@ -182,6 +182,22 @@ def test_data_info_context_defaults_distinguish_cli_from_mcp(tmp_path: Path) -> 
     assert config.get_data_info_config("cli").heads == 5
     assert config.get_data_info_config("mcp").heads == 0
     assert config.get_data_info_config("api").metrics == DEFAULT_DATA_INFO_METRICS
+
+
+def test_data_info_metrics_always_keep_defaults_and_deduplicate_extras(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+[MCP.TOOLS.DATA_INFO]
+metrics = ["Q1", "mean", "unsupported", "q1", "MED"]
+""",
+    )
+
+    settings = Config(config_file=config_path).get_data_info_config("mcp")
+
+    assert settings.metrics == DEFAULT_DATA_INFO_METRICS + ("q1", "med")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_tool_context.py
+++ b/tests/test_config_tool_context.py
@@ -1,0 +1,271 @@
+"""Tests for context-aware tool configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from stata_mcp.config import DEFAULT_DATA_INFO_METRICS, Config
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(content.strip(), encoding="utf-8")
+    return config_path
+
+
+def test_help_context_falls_back_per_key_to_generic_section(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+[HELP]
+IS_CACHE = false
+IS_SAVE = false
+
+[MCP.TOOLS.HELP]
+IS_CACHE = true
+""",
+    )
+
+    config = Config(config_file=config_path)
+
+    assert config.get_help_config("mcp").is_cache is True
+    assert config.get_help_config("mcp").is_save is False
+    assert config.get_help_config("cli").is_cache is False
+    assert config.IS_CACHE_HELP is False
+
+
+def test_context_environment_overrides_generic_environment_and_toml(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+[HELP]
+IS_CACHE = false
+
+[MCP.TOOLS.HELP]
+IS_CACHE = false
+""",
+    )
+    monkeypatch.setenv("STATA_MCP__HELP__IS_CACHE", "false")
+    monkeypatch.setenv("STATA_MCP__MCP__TOOLS__HELP__IS_CACHE", "true")
+
+    assert Config(config_file=config_path).get_help_config("mcp").is_cache is True
+
+
+def test_system_generic_value_overrides_context_environment_and_debug_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    system_config_path = tmp_path / "etc" / "statamcp" / "config.toml"
+    system_config_path.parent.mkdir(parents=True)
+    system_config_path.write_text("[HELP]\nIS_CACHE = false", encoding="utf-8")
+    debug_config_path = _write_config(
+        tmp_path,
+        """
+[MCP.TOOLS.HELP]
+IS_CACHE = true
+""",
+    )
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(Config, "SYSTEM_CONFIG_FILE", system_config_path)
+    monkeypatch.setenv("STATA_MCP__MCP__TOOLS__HELP__IS_CACHE", "true")
+
+    settings = Config(config_file=debug_config_path).get_help_config("mcp")
+
+    assert settings.is_cache is False
+
+
+def test_legacy_help_environment_alias_remains_supported(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("STATA_MCP__CACHE_HELP", "false")
+
+    config = Config(config_file=tmp_path / "missing.toml")
+
+    assert config.get_help_config("mcp").is_cache is False
+    assert config.IS_CACHE_HELP is False
+
+
+def test_data_info_context_uses_canonical_then_legacy_generic_tables(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+[data_info]
+is_cache = false
+string_keep_number = 7
+decimal_places = 2
+hash_length = 8
+heads = 1
+
+[DATA_INFO]
+decimal_places = 4
+
+[MCP.TOOLS.DATA_INFO]
+is_cache = true
+metrics = ["obs", "med", "q1"]
+hash_length = 16
+""",
+    )
+
+    settings = Config(config_file=config_path).get_data_info_config("mcp")
+
+    assert settings.is_cache is True
+    assert settings.metrics == ("obs", "med", "q1")
+    assert settings.string_keep_number == 7
+    assert settings.decimal_places == 4
+    assert settings.hash_length == 16
+    assert settings.heads == 1
+
+
+def test_data_info_context_defaults_distinguish_cli_from_mcp(tmp_path: Path) -> None:
+    config = Config(config_file=tmp_path / "missing.toml")
+
+    assert config.get_data_info_config("cli").heads == 5
+    assert config.get_data_info_config("mcp").heads == 0
+    assert config.get_data_info_config("api").metrics == DEFAULT_DATA_INFO_METRICS
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "attribute", "default"),
+    [
+        ("metrics", '["unknown"]', "metrics", DEFAULT_DATA_INFO_METRICS),
+        ("string_keep_number", "-1", "string_keep_number", 10),
+        ("decimal_places", "-1", "decimal_places", 3),
+        ("hash_length", "0", "hash_length", 12),
+        ("hash_length", "33", "hash_length", 12),
+    ],
+)
+def test_invalid_data_info_values_fall_back_safely(
+    tmp_path: Path,
+    key: str,
+    value: str,
+    attribute: str,
+    default,
+) -> None:
+    config_path = _write_config(
+        tmp_path,
+        f"""
+[MCP.TOOLS.DATA_INFO]
+{key} = {value}
+""",
+    )
+
+    settings = Config(config_file=config_path).get_data_info_config("mcp")
+
+    assert getattr(settings, attribute) == default
+
+
+def test_legacy_data_info_environment_aliases_remain_supported(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("STATA_MCP__DATA_INFO_IS_CACHE", "false")
+    monkeypatch.setenv("STATA_MCP_DATA_INFO_STRING_KEEP_NUMBER", "4")
+    monkeypatch.setenv("STATA_MCP_DATA_INFO_DECIMAL_PLACES", "1")
+    monkeypatch.setenv("STATA_MCP_DATA_INFO_HASH_LENGTH", "6")
+
+    settings = Config(
+        config_file=tmp_path / "missing.toml"
+    ).get_data_info_config("mcp")
+
+    assert settings.is_cache is False
+    assert settings.string_keep_number == 4
+    assert settings.decimal_places == 1
+    assert settings.hash_length == 6
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        ("HELP", False),
+        ("DATA_INFO", True),
+        ("STATA_DO", True),
+    ],
+)
+def test_mcp_tool_switches_default_to_enabled_and_read_explicit_values(
+    tmp_path: Path,
+    tool_name: str,
+    expected: bool,
+) -> None:
+    config_path = _write_config(
+        tmp_path,
+        """
+[MCP.TOOLS]
+ENABLE_HELP = false
+ENABLE_DATA_INFO = true
+""",
+    )
+    config = Config(config_file=config_path)
+
+    assert config.is_tool_enabled("mcp", tool_name) is expected
+
+
+def test_tool_switch_rejects_unknown_context(tmp_path: Path) -> None:
+    config = Config(config_file=tmp_path / "missing.toml")
+
+    with pytest.raises(ValueError, match="Unsupported tool context"):
+        config.is_tool_enabled("desktop", "HELP")  # type: ignore[arg-type]
+
+
+def test_additional_allowed_dirs_expand_and_anchor_relative_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    working_dir = tmp_path / "work"
+    home_dir.mkdir()
+    working_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home_dir)
+    monkeypatch.setenv("HOME", home_dir.as_posix())
+    config_path = _write_config(
+        tmp_path,
+        f"""
+[PROJECT]
+WORKING_DIR = "{working_dir.as_posix()}"
+
+[SECURITY]
+ADDITIONAL_ALLOWED_DIRS = ["~/shared", "project-data", "project-data"]
+""",
+    )
+
+    config = Config(config_file=config_path)
+
+    assert config.ADDITIONAL_ALLOWED_DIRS == (
+        (home_dir / "shared").resolve(),
+        (working_dir / "project-data").resolve(),
+    )
+
+
+def test_user_additional_allowed_dirs_override_project_security(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    user_config_dir = home_dir / ".statamcp"
+    project_config_dir = project_dir / ".statamcp"
+    user_config_dir.mkdir(parents=True)
+    project_config_dir.mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home_dir)
+    monkeypatch.chdir(project_dir)
+    (user_config_dir / "config.toml").write_text(
+        '[SECURITY]\nADDITIONAL_ALLOWED_DIRS = ["user-data"]',
+        encoding="utf-8",
+    )
+    (project_config_dir / "config.toml").write_text(
+        '[SECURITY]\nADDITIONAL_ALLOWED_DIRS = ["project-data"]',
+        encoding="utf-8",
+    )
+
+    config = Config()
+
+    assert config.ADDITIONAL_ALLOWED_DIRS == (
+        (project_dir / "user-data").resolve(),
+    )

--- a/tests/test_config_tool_context.py
+++ b/tests/test_config_tool_context.py
@@ -79,6 +79,58 @@ IS_CACHE = true
     assert settings.is_cache is False
 
 
+def test_project_generic_value_overrides_user_context_specific_value(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    user_config_dir = home_dir / ".statamcp"
+    project_config_dir = project_dir / ".statamcp"
+    user_config_dir.mkdir(parents=True)
+    project_config_dir.mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home_dir)
+    monkeypatch.chdir(project_dir)
+    (user_config_dir / "config.toml").write_text(
+        "[MCP.TOOLS.HELP]\nIS_CACHE = true",
+        encoding="utf-8",
+    )
+    (project_config_dir / "config.toml").write_text(
+        "[HELP]\nIS_CACHE = false",
+        encoding="utf-8",
+    )
+
+    settings = Config().get_help_config("mcp")
+
+    assert settings.is_cache is False
+
+
+def test_project_generic_data_info_value_overrides_user_context_value(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    user_config_dir = home_dir / ".statamcp"
+    project_config_dir = project_dir / ".statamcp"
+    user_config_dir.mkdir(parents=True)
+    project_config_dir.mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home_dir)
+    monkeypatch.chdir(project_dir)
+    (user_config_dir / "config.toml").write_text(
+        "[CLI.TOOLS.DATA_INFO]\nheads = 9",
+        encoding="utf-8",
+    )
+    (project_config_dir / "config.toml").write_text(
+        "[data_info]\nheads = 2",
+        encoding="utf-8",
+    )
+
+    settings = Config().get_data_info_config("cli")
+
+    assert settings.heads == 2
+
+
 def test_legacy_help_environment_alias_remains_supported(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_config_tool_context.py
+++ b/tests/test_config_tool_context.py
@@ -200,6 +200,11 @@ metrics = ["Q1", "mean", "unsupported", "q1", "MED"]
     assert settings.metrics == DEFAULT_DATA_INFO_METRICS + ("q1", "med")
 
 
+def test_data_info_metrics_reject_unordered_collections() -> None:
+    with pytest.raises(TypeError, match="string, list, or tuple"):
+        Config._to_metrics({"q1", "med"})
+
+
 @pytest.mark.parametrize(
     ("key", "value", "attribute", "default"),
     [

--- a/tests/test_mcp_servers_security_log.py
+++ b/tests/test_mcp_servers_security_log.py
@@ -188,6 +188,30 @@ def test_read_log_rejection_log_redacts_local_path(
     assert "allowed_directory" not in messages
 
 
+def test_read_log_allows_additional_configured_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    stubbed_mcp_servers,
+    tmp_path: Path,
+) -> None:
+    statamcp_dir = tmp_path / "statamcp"
+    shared_dir = tmp_path / "shared"
+    statamcp_dir.mkdir()
+    shared_dir.mkdir()
+    log_file = shared_dir / "shared.log"
+    log_file.write_text("shared content", encoding="utf-8")
+    fake_folder = SimpleNamespace(path=statamcp_dir)
+    fake_config = SimpleNamespace(
+        STATA_MCP_FOLDER=fake_folder,
+        ADDITIONAL_ALLOWED_DIRS=(shared_dir,),
+        ENABLE_STRUCTURED_LOG=False,
+    )
+    monkeypatch.setattr(stubbed_mcp_servers, "config", fake_config)
+
+    result = stubbed_mcp_servers.read_log(log_file.as_posix())
+
+    assert result == "shared content"
+
+
 def test_read_log_structured_parsing_depends_only_on_config(
     monkeypatch: pytest.MonkeyPatch,
     stubbed_mcp_servers,


### PR DESCRIPTION
## What changed

- Added a single context-aware configuration resolver for MCP, CLI, and generic API settings.
- Preserved source authority before tool specificity:
  - Linux system config
  - environment variables
  - debug config or project/user config
  - built-in defaults
- Added per-key fallback for `MCP.TOOLS.HELP`, `CLI.TOOLS.HELP`, `MCP.TOOLS.DATA_INFO`, and `CLI.TOOLS.DATA_INFO`.
- Added MCP `ENABLE_*` tool switches without allowing them to bypass profiles or platform restrictions.
- Removed independent TOML/environment parsing from `DataInfoBase`; runtime callers pass resolved settings, while direct handler users retain compatibility through the shared `Config` resolver.
- Added the `med` data-info metric and CLI `data-info --heads`.
- Isolated data-info caches by source, content, reader options, and output settings so MCP, CLI, API, and direct calls cannot reuse incompatible summaries.
- Applied `SECURITY.ADDITIONAL_ALLOWED_DIRS` consistently to do-file, data-info, guarded data-command, and read-log boundaries.
- Added a TOML-aware startup migration from legacy `[data_info]` to canonical `[DATA_INFO]`. It ignores table-like text inside multiline strings, accepts valid quoted/spaced headers, patches the existing inode to retain ACLs and metadata, detects concurrent edits, and rolls back failed writes.

## Why

The example configuration introduced context-specific tool settings, but the runtime still read mostly generic sections. Data-info also opened `~/.statamcp/config.toml` directly, bypassing project, debug, environment, and Linux system precedence.

This change gives all supported tool settings one resolution model and keeps configuration source authority separate from MCP/CLI specificity.

## Compatibility and safety

- Existing `IS_CACHE_HELP`, `IS_SAVE_HELP`, and `DATA_INFO_IS_CACHE` properties remain available.
- Existing direct `CsvDataInfo`/`DtaDataInfo`-style calls still honor legacy environment variables and generic TOML settings; explicit constructor arguments remain authoritative.
- Existing lowercase `[data_info]` and legacy environment variables remain supported, including when automatic migration cannot write the file.
- If both `[data_info]` and `[DATA_INFO]` exist, neither section is rewritten; `[DATA_INFO]` wins per key and a warning explains the conflict.
- Project settings still override user settings for regular sections.
- User security settings still override project security settings.
- Linux system configuration remains authoritative.
- MCP switches can disable profile candidates but cannot expose unsafe or platform-ineligible tools.
- Additional allowed directories extend strict roots; they do not disable path resolution, traversal, or symlink checks.

## Validation

- `uv run pytest -q` — 690 passed, 1 platform-capability test skipped
- MCP stdio schema/response regression test passed.
- CLI `data-info --heads` help and parsing checks passed.
- Branch diff passed `git diff --check`.

## Deliberately excluded

`config.example.toml` is intentionally not part of this PR. A comprehensive local version has been prepared for a separate follow-up after review.
