### PR TITLE
feat: gate get_data_info MCP tool behind beta flag on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,11 @@ that lightweight import behavior.
 | `all` (default) | all `core` tools plus `read_log` |
 | `unsafe` | all standard tools plus `ado_package_install` |
 
-`help` is filtered out on Windows. A process cannot switch profiles after tools
-have been registered; start a new process instead.
+`help` is filtered out on Windows. `get_data_info` is also hidden on Windows by
+default (a known Windows-only MCP-wrapper bug); `[BETA] enable_windows_data_info`
+re-enables it there via the `windows_beta_only` gate in `register_tools`. A
+process cannot switch profiles after tools have been registered; start a new
+process instead.
 
 `write_dofile` remains a direct Python API helper but is not registered as an MCP
 tool. Do not add it back to `_TOOL_REGISTRY` without an explicit security review.

--- a/config.example.toml
+++ b/config.example.toml
@@ -15,6 +15,9 @@ MAX_ASYNC_DO = 3
 enable_data_info_url_guard = false
 data_info_allowed_url_domains = []
 enable_structured_log = false
+# Windows only: re-enable the get_data_info MCP tool, which is hidden on
+# Windows by default due to a known Windows-only MCP-wrapper bug.
+enable_windows_data_info = false
 
 [HELP]
 IS_CACHE = true

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -11,6 +11,7 @@ MAX_ASYNC_DO = 3
 enable_data_info_url_guard = false
 data_info_allowed_url_domains = []
 enable_structured_log = false
+enable_windows_data_info = false
 ```
 
 ## Parameters
@@ -22,6 +23,7 @@ enable_structured_log = false
 | `enable_data_info_url_guard` | Boolean | `false` | None | Enables URL validation and domain allowlist checks for URL data sources passed to `get_data_info`. |
 | `data_info_allowed_url_domains` | List[str] | `[]` | None | Allowed hostnames when the `get_data_info` URL guard is enabled. |
 | `enable_structured_log` | Boolean | `false` | None | Enables structured log parsing for the `read_log` tool and API. |
+| `enable_windows_data_info` | Boolean | `false` | `STATA_MCP__ENABLE_WINDOWS_DATA_INFO` | Windows only. Re-enables the `get_data_info` MCP tool on Windows, where it is hidden by default because its MCP wrapper has a known Windows-only bug. |
 
 
 ## `IS_ASYNC_DO`
@@ -89,5 +91,34 @@ enable_structured_log = true
 ```
 
 When this switch is `false`, `read_log` returns raw file content. When it is `true`, supported logs are parsed into structured formats (`full`, `core`, or `dict`) via `StataLog`. MCP, CLI, and API calls all use this same switch and behavior.
+
+Boolean string values must be `true` or `false`. Values such as `on` and `off` are not accepted and fall back to the default.
+
+## `enable_windows_data_info`
+
+`enable_windows_data_info` re-enables the `get_data_info` MCP tool on Windows.
+
+```toml
+[BETA]
+enable_windows_data_info = true
+```
+
+or:
+
+```bash
+export STATA_MCP__ENABLE_WINDOWS_DATA_INFO=true
+```
+
+**Why this switch exists.** The `get_data_info` MCP wrapper works correctly
+through the CLI and API on Windows, but the MCP-layer path has a Windows-only
+bug that has resisted debugging for over a month. Rather than advertise a broken
+tool, the MCP server hides `get_data_info` from the tool list on Windows by
+default. This switch is the opt-in for users who understand the risk and still
+want the tool exposed on Windows.
+
+This switch has no effect on macOS or Linux, where `get_data_info` is always
+registered. It only controls MCP tool registration; the CLI/API code paths are
+unaffected on every platform. Once the underlying Windows MCP bug is fixed this
+gate will be removed and `get_data_info` will register unconditionally again.
 
 Boolean string values must be `true` or `false`. Values such as `on` and `off` are not accepted and fall back to the default.

--- a/docs/beta.zh.md
+++ b/docs/beta.zh.md
@@ -11,6 +11,7 @@ MAX_ASYNC_DO = 3
 enable_data_info_url_guard = false
 data_info_allowed_url_domains = []
 enable_structured_log = false
+enable_windows_data_info = false
 ```
 
 ## 参数表
@@ -22,6 +23,7 @@ enable_structured_log = false
 | `enable_data_info_url_guard` | Boolean | `false` | 无 | 对传给 `get_data_info` 的 URL 数据源启用 URL 校验和域名白名单检查。 |
 | `data_info_allowed_url_domains` | List[str] | `[]` | 无 | URL guard 启用后允许访问的主机名列表。 |
 | `enable_structured_log` | Boolean | `false` | 无 | 为 `read_log` 工具和 API 启用结构化日志解析。 |
+| `enable_windows_data_info` | Boolean | `false` | `STATA_MCP__ENABLE_WINDOWS_DATA_INFO` | 仅限 Windows。在 Windows 上重新启用 `get_data_info` MCP 工具；该工具因 MCP 封装层存在已知的 Windows 专属 bug，默认在 Windows 上被隐藏。 |
 
 
 ## `IS_ASYNC_DO`
@@ -89,5 +91,31 @@ enable_structured_log = true
 ```
 
 当该开关为 `false` 时，`read_log` 返回原始文件内容。当该开关为 `true` 时，支持的日志会通过 `StataLog` 解析为结构化格式（`full`、`core` 或 `dict`）。MCP、CLI 和 API 调用都使用同一个开关和相同的处理逻辑。
+
+Boolean 字符串值必须是 `true` 或 `false`。`on`、`off` 等值不会被接受，会回退到默认值。
+
+## `enable_windows_data_info`
+
+`enable_windows_data_info` 用于在 Windows 上重新启用 `get_data_info` MCP 工具。
+
+```toml
+[BETA]
+enable_windows_data_info = true
+```
+
+也可以通过环境变量启用：
+
+```bash
+export STATA_MCP__ENABLE_WINDOWS_DATA_INFO=true
+```
+
+**为什么需要这个开关。** `get_data_info` 在 Windows 上通过 CLI 和 API 都能正常工作，
+但 MCP 层的执行路径存在一个 Windows 专属的 bug，调试了一个多月仍未找到根因。为了避免
+对外暴露一个有问题的工具，MCP server 默认在 Windows 上将 `get_data_info` 从工具列表中
+隐藏。这个开关是给了解风险、仍希望在 Windows 上暴露该工具的用户使用的显式选项。
+
+该开关对 macOS 和 Linux 无任何影响——在这些平台上 `get_data_info` 始终注册。它只控制
+MCP 工具的注册，不影响任何平台上的 CLI/API 执行路径。一旦底层的 Windows MCP bug 被修复，
+这个门禁会被移除，`get_data_info` 将重新无条件注册。
 
 Boolean 字符串值必须是 `true` 或 `false`。`on`、`off` 等值不会被接受，会回退到默认值。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ MAX_ASYNC_DO = 3
 enable_data_info_url_guard = false
 data_info_allowed_url_domains = []
 enable_structured_log = false
+enable_windows_data_info = false
 
 [HELP]
 IS_CACHE = true
@@ -407,7 +408,7 @@ Maximum RAM limit in megabytes.
 
 ### BETA Section
 
-Beta and experimental options live in the `[BETA]` section. This includes async `stata_do`, the optional `get_data_info` URL domain guard, and structured log parsing for `read_log`. See [Beta Configuration](beta.md) for the complete list, recommended defaults, and behavior notes.
+Beta and experimental options live in the `[BETA]` section. This includes async `stata_do`, the optional `get_data_info` URL domain guard, structured log parsing for `read_log`, and the Windows-only `enable_windows_data_info` switch that re-enables `get_data_info` on Windows. See [Beta Configuration](beta.md) for the complete list, recommended defaults, and behavior notes.
 
 ### STATA Section
 

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -64,6 +64,7 @@ MAX_ASYNC_DO = 3
 enable_data_info_url_guard = false
 data_info_allowed_url_domains = []
 enable_structured_log = false
+enable_windows_data_info = false
 
 [HELP]
 IS_CACHE = true
@@ -389,7 +390,7 @@ Python API 不要求调用方确认。CLI 未传入 `-y` 或 `--yes` 时会进�
 
 ### BETA 分区
 
-Beta 和实验性选项位于 `[BETA]` 分区，包括异步 `stata_do`、可选的 `get_data_info` URL 域名白名单，以及 `read_log` 的结构化日志解析。完整参数、推荐默认值和行为说明见 [Beta 配置](beta.md)。
+Beta 和实验性选项位于 `[BETA]` 分区，包括异步 `stata_do`、可选的 `get_data_info` URL 域名白名单、`read_log` 的结构化日志解析，以及仅限 Windows、用于在 Windows 上重新启用 `get_data_info` 的 `enable_windows_data_info` 开关。完整参数、推荐默认值和行为说明见 [Beta 配置](beta.md)。
 
 ### STATA 分区
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,9 +1,16 @@
 # MCP.Tools
 
-Tools are partitioned into three profiles inside `_TOOL_REGISTRY`. `stata-mcp server --core` registers only `stata_do`, `get_data_info`, and `help`. `stata-mcp server --all` (the default) registers standard tools but excludes high-risk third-party installation. `stata-mcp server --unsafe` adds `ado_package_install`. The `help` tool is filtered out on Windows. `write_dofile` is no longer registered as an MCP tool.
+Tools are partitioned into three profiles inside `_TOOL_REGISTRY`. `stata-mcp server --core` registers only `stata_do`, `get_data_info`, and `help`. `stata-mcp server --all` (the default) registers standard tools but excludes high-risk third-party installation. `stata-mcp server --unsafe` adds `ado_package_install`. The `help` tool is filtered out on Windows. `get_data_info` is also hidden on Windows by default because its MCP wrapper has a known Windows-only bug; re-enable it there with `[BETA] enable_windows_data_info=true`. `write_dofile` is no longer registered as an MCP tool.
 
 ---
 ## get_data_info
+> Hidden on Windows by default; re-enable with `[BETA] enable_windows_data_info=true`
+
+On Windows the `get_data_info` MCP tool is not registered by default because its
+MCP wrapper has a known Windows-only bug (the CLI and API paths are unaffected).
+Set `[BETA] enable_windows_data_info=true` to expose it on Windows anyway. macOS
+and Linux always register the tool. See [Beta Configuration](../beta.md).
+
 ```python
 def get_data_info(data_path: str | Path,
                   vars_list: List[str] | None = None,

--- a/docs/mcp/tools.zh.md
+++ b/docs/mcp/tools.zh.md
@@ -1,9 +1,15 @@
 # MCP.Tools
 
-工具在 `_TOOL_REGISTRY` 中按三种 profile 划分。`stata-mcp server --core` 只注册 `stata_do`、`get_data_info`、`help`；`stata-mcp server --all`（默认）注册标准工具，但不包含高风险第三方安装；`stata-mcp server --unsafe` 会额外注册 `ado_package_install`。`help` 在 Windows 上会被过滤。`write_dofile` 已不再注册为 MCP 工具。
+工具在 `_TOOL_REGISTRY` 中按三种 profile 划分。`stata-mcp server --core` 只注册 `stata_do`、`get_data_info`、`help`；`stata-mcp server --all`（默认）注册标准工具，但不包含高风险第三方安装；`stata-mcp server --unsafe` 会额外注册 `ado_package_install`。`help` 在 Windows 上会被过滤。`get_data_info` 同样默认在 Windows 上被隐藏（因为其 MCP 封装层存在已知的 Windows 专属 bug），可通过 `[BETA] enable_windows_data_info=true` 在 Windows 上重新启用。`write_dofile` 已不再注册为 MCP 工具。
 
 ---
 ## get_data_info
+> 默认在 Windows 上隐藏；可通过 `[BETA] enable_windows_data_info=true` 重新启用
+
+在 Windows 上，`get_data_info` MCP 工具默认不注册，因为其 MCP 封装层存在一个已知的
+Windows 专属 bug（CLI 和 API 路径不受影响）。设置 `[BETA] enable_windows_data_info=true`
+可在 Windows 上强制暴露该工具。macOS 和 Linux 始终注册该工具。详见 [Beta 配置](../beta.md)。
+
 ```python
 def get_data_info(data_path: str | Path,
                   vars_list: List[str] | None = None,

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -935,6 +935,28 @@ class Config:
             validator=lambda x: isinstance(x, bool),
         )
 
+    @cached_property
+    def ENABLE_WINDOWS_DATA_INFO(self) -> bool:
+        # BETA gate for the get_data_info MCP tool on Windows.
+        #
+        # WHY: get_data_info works fine through the CLI on Windows, but the MCP
+        # wrapper has a Windows-only bug that has resisted debugging for over a
+        # month. To avoid shipping a broken tool, the MCP layer hides
+        # get_data_info on Windows unless this beta flag is explicitly enabled.
+        # Non-Windows platforms are unaffected and never consult this flag.
+        #
+        # HOW TO REVERT (once the Windows MCP bug is fixed): delete this property,
+        # remove the "windows_beta_only" gate in mcp_servers.register_tools, and
+        # drop the "windows_beta_only": True entry from the get_data_info registry
+        # entry. That restores get_data_info on Windows unconditionally.
+        return self._get_config_value(
+            config_keys=["BETA", "enable_windows_data_info"],
+            env_var="STATA_MCP__ENABLE_WINDOWS_DATA_INFO",
+            default=False,
+            converter=self._to_bool,
+            validator=lambda x: isinstance(x, bool),
+        )
+
     @property
     def STATA_MCP_DIRECTORY(self) -> Path:
         base_dir = Path.home() / ".statamcp"

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -830,6 +830,13 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "func": get_data_info,
         "config_name": "DATA_INFO",
         "profiles": {"core", "all"},
+        # BETA gate for Windows only. get_data_info works via the CLI on Windows
+        # but the MCP wrapper has a Windows-only bug that has resisted debugging
+        # for over a month, so it is hidden from the MCP tool list on Windows
+        # unless config.ENABLE_WINDOWS_DATA_INFO (BETA.enable_windows_data_info)
+        # is turned on. See the gate in register_tools below.
+        # TO REVERT once the bug is fixed: remove this key and the matching gate.
+        "windows_beta_only": True,
     },
     "help": {
         "description": (
@@ -884,6 +891,17 @@ def register_tools(server: FastMCP, profile: str = "all") -> None:
 
     for name, meta in _TOOL_REGISTRY.items():
         if meta.get("unix_only") and not config.IS_UNIX:
+            continue
+        # BETA gate: hide Windows-only-buggy tools unless the beta flag is on.
+        # get_data_info's MCP wrapper is broken on Windows (see registry note),
+        # so on Windows it registers only when ENABLE_WINDOWS_DATA_INFO is set.
+        # TO REVERT once fixed: delete this block and the "windows_beta_only"
+        # registry key so the tool always registers on Windows again.
+        if (
+            meta.get("windows_beta_only")
+            and not config.IS_UNIX
+            and not config.ENABLE_WINDOWS_DATA_INFO
+        ):
             continue
         eligible_profiles = {"all", "unsafe"} if profile == "unsafe" else {profile}
         if not eligible_profiles.intersection(meta["profiles"]):

--- a/tests/cli/test_server_registration.py
+++ b/tests/cli/test_server_registration.py
@@ -107,10 +107,16 @@ def _set_registry(
     mcp_servers,
     *,
     unix: bool,
+    enable_windows_data_info: bool = True,
 ) -> None:
     registry = {
         "stata_do": {"description": "d", "func": lambda: None, "profiles": {"core", "all"}},
-        "get_data_info": {"description": "d", "func": lambda: None, "profiles": {"core", "all"}},
+        "get_data_info": {
+            "description": "d",
+            "func": lambda: None,
+            "profiles": {"core", "all"},
+            "windows_beta_only": True,
+        },
         "help": {"description": "d", "func": lambda: None, "profiles": {"core", "all"}, "unix_only": True},
         "read_log": {"description": "d", "func": lambda: None, "profiles": {"all"}},
         "ado_package_install": {
@@ -127,6 +133,7 @@ def _set_registry(
         "config",
         SimpleNamespace(
             IS_UNIX=unix,
+            ENABLE_WINDOWS_DATA_INFO=enable_windows_data_info,
         ),
         raising=False,
     )
@@ -221,13 +228,44 @@ def test_register_tools_all_applies_platform_and_deprecated_filters(
     loaded_modules,
 ):
     mcp_servers, _ = loaded_modules
-    _set_registry(monkeypatch, mcp_servers, unix=False)
+    # Windows with the beta flag on keeps get_data_info available.
+    _set_registry(monkeypatch, mcp_servers, unix=False, enable_windows_data_info=True)
     server = _DummyServer()
 
     mcp_servers.register_tools(server, profile="all")
 
     assert set(server.tools) == {"stata_do", "get_data_info", "read_log"}
     assert server.resources == []
+
+
+def test_register_tools_hides_get_data_info_on_windows_without_beta(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_modules,
+):
+    # get_data_info's MCP wrapper is broken on Windows, so it must be hidden
+    # from the tool list unless the beta flag is explicitly enabled.
+    mcp_servers, _ = loaded_modules
+    _set_registry(monkeypatch, mcp_servers, unix=False, enable_windows_data_info=False)
+    server = _DummyServer()
+
+    mcp_servers.register_tools(server, profile="all")
+
+    assert "get_data_info" not in server.tools
+    assert set(server.tools) == {"stata_do", "read_log"}
+
+
+def test_register_tools_keeps_get_data_info_on_unix_regardless_of_beta(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_modules,
+):
+    # The Windows-only gate must never affect Unix platforms.
+    mcp_servers, _ = loaded_modules
+    _set_registry(monkeypatch, mcp_servers, unix=True, enable_windows_data_info=False)
+    server = _DummyServer()
+
+    mcp_servers.register_tools(server, profile="all")
+
+    assert "get_data_info" in server.tools
 
 
 def test_register_tools_applies_config_switch_after_profile_filter(


### PR DESCRIPTION
## Summary

The `get_data_info` MCP wrapper has a Windows-only bug that has resisted debugging for over a month, while the CLI code path works fine. To avoid shipping a broken tool, this change hides `get_data_info` from the **MCP tool list on Windows** unless a new beta flag is explicitly enabled. Non-Windows (Unix/macOS/Linux) platforms are completely unaffected.

## Changes

- **`src/stata_mcp/config.py`** — new `ENABLE_WINDOWS_DATA_INFO` property, sourced from `BETA.enable_windows_data_info` (config file) or `STATA_MCP__ENABLE_WINDOWS_DATA_INFO` (env), defaulting to `False`.
- **`src/stata_mcp/mcp_servers.py`** — `get_data_info` registry entry marked `"windows_beta_only": True`; `register_tools` skips such tools on Windows unless the beta flag is on.
- **`tests/cli/test_server_registration.py`** — added coverage: tool hidden on Windows without beta, present on Windows with beta, and always present on Unix regardless of the flag.

## How to revert (once the Windows MCP bug is fixed)

Both the config property and the `register_tools` gate carry inline comments explaining this. In short:
1. Delete the `ENABLE_WINDOWS_DATA_INFO` property in `config.py`.
2. Remove the `windows_beta_only` gate block in `register_tools`.
3. Drop the `"windows_beta_only": True` key from the `get_data_info` registry entry.

This restores `get_data_info` on Windows unconditionally.

## Notes

- Behavior of the tool itself is unchanged — this only affects whether it is registered/advertised in the MCP tool list on Windows.
- One pre-existing test failure (`test_debug_config_file_ignores_user_and_project_config`) is an environment artifact (a `/etc/statamcp/config.toml` present in the CI container) and reproduces on the base branch; it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JVFgQ7K1VN9m8TK6gr9g9

---
_Generated by [Claude Code](https://claude.ai/code/session_015JVFgQ7K1VN9m8TK6gr9g9)_