### PR TITLE
fix(stata_do): derive Windows batch filename from uuid, not do-file stem

### DIFF
--- a/src/stata_mcp/stata/stata_do/do.py
+++ b/src/stata_mcp/stata/stata_do/do.py
@@ -220,6 +220,48 @@ class StataDo:
         """
         return f"stata_batch__{uuid4().hex}.do"
 
+    @classmethod
+    def _create_windows_batch_file(
+        cls,
+        dofile_path: Path,
+        log_file: Path,
+        is_replace: bool,
+    ) -> Path:
+        """Atomically create and write a random Windows wrapper do-file."""
+        batch_prefix = Path(cls._generate_batch_file_name()).stem
+        replace_clause = ", replace" if is_replace else ""
+        batch_file: Optional[Path] = None
+
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                prefix=f"{batch_prefix}__",
+                suffix=".do",
+                delete=False,
+                newline="\n",
+            ) as file:
+                batch_file = Path(file.name)
+                file.write("capture log close\n")
+                file.write(f'log using "{log_file}"{replace_clause}\n')
+                file.write(f'do "{dofile_path}"\n')
+                file.write("log close\n")
+                file.write("exit, STATA\n")
+        except Exception:
+            if batch_file is not None:
+                try:
+                    batch_file.unlink(missing_ok=True)
+                except OSError as error:
+                    logging.warning(
+                        "Failed to remove incomplete temporary batch file %s: %s",
+                        batch_file,
+                        error,
+                    )
+            raise
+
+        assert batch_file is not None
+        return batch_file
+
     def _execute_unix_like(
         self,
         dofile_path: Path,
@@ -309,19 +351,12 @@ class StataDo:
             is_replace: Whether replace the log file if exists.
             timeout: Maximum execution time in seconds. None means no timeout.
         """
-        # Windows approach - use the /e flag to run a batch command
-        # Create a temporary batch file in system temp directory
-        batch_file = Path(tempfile.gettempdir()) / self._generate_batch_file_name()
-
-        replace_clause = ", replace" if is_replace else ""
+        batch_file = self._create_windows_batch_file(
+            dofile_path,
+            log_file,
+            is_replace,
+        )
         try:
-            with open(batch_file, "w", encoding="utf-8") as f:
-                f.write("capture log close\n")
-                f.write(f'log using "{log_file}"{replace_clause}\n')
-                f.write(f'do "{dofile_path}"\n')
-                f.write("log close\n")
-                f.write("exit, STATA\n")
-
             # Run Stata on Windows using /e to execute the batch file
             cmd = [self.STATA_CLI, "/e", "do", batch_file.as_posix()]
             result = subprocess.run(
@@ -459,20 +494,14 @@ class StataDo:
         Raises:
             RuntimeError: Stata execution error
         """
-        # Windows approach - use the /e flag to run a batch command
-        # Create a temporary batch file in system temp directory
-        batch_file = Path(tempfile.gettempdir()) / self._generate_batch_file_name()
+        batch_file = self._create_windows_batch_file(
+            dofile_path,
+            log_file,
+            is_replace,
+        )
         proc: Optional[subprocess.Popen] = None
 
-        replace_clause = ", replace" if is_replace else ""
         try:
-            with open(batch_file, "w", encoding="utf-8") as f:
-                f.write("capture log close\n")
-                f.write(f'log using "{log_file}"{replace_clause}\n')
-                f.write(f'do "{dofile_path}"\n')
-                f.write("log close\n")
-                f.write("exit, STATA\n")
-
             # Run Stata on Windows using /e to execute the batch file
             # Use Popen instead of run to enable monitoring
             cmd = [self.STATA_CLI, "/e", "do", str(batch_file)]

--- a/src/stata_mcp/stata/stata_do/do.py
+++ b/src/stata_mcp/stata/stata_do/do.py
@@ -15,6 +15,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
+from uuid import uuid4
 
 from ...utils import get_nowtime
 
@@ -209,6 +210,16 @@ class StataDo:
             raise ValueError("Invalid log_file_name. Path traversal is not allowed.")
         return log_file
 
+    @staticmethod
+    def _generate_batch_file_name() -> str:
+        """Random batch filename for the Windows launcher.
+
+        The name must never be derived from user-controlled input (e.g. the
+        do-file stem): the batch path is passed to a shell on Windows, so any
+        metacharacter smuggled into the filename would be interpreted there.
+        """
+        return f"stata_batch__{uuid4().hex}.do"
+
     def _execute_unix_like(
         self,
         dofile_path: Path,
@@ -300,7 +311,7 @@ class StataDo:
         """
         # Windows approach - use the /e flag to run a batch command
         # Create a temporary batch file in system temp directory
-        batch_file = Path(tempfile.gettempdir()) / f"stata_batch__{dofile_path.stem}.do"
+        batch_file = Path(tempfile.gettempdir()) / self._generate_batch_file_name()
 
         replace_clause = ", replace" if is_replace else ""
         try:
@@ -450,7 +461,7 @@ class StataDo:
         """
         # Windows approach - use the /e flag to run a batch command
         # Create a temporary batch file in system temp directory
-        batch_file = Path(tempfile.gettempdir()) / f"stata_batch__{dofile_path.stem}.do"
+        batch_file = Path(tempfile.gettempdir()) / self._generate_batch_file_name()
         proc: Optional[subprocess.Popen] = None
 
         replace_clause = ", replace" if is_replace else ""

--- a/tests/stata/test_do_batch_filename.py
+++ b/tests/stata/test_do_batch_filename.py
@@ -10,14 +10,19 @@ replaced ``{dofile_path.stem}`` with a random uuid-based name in both
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 from stata_mcp.stata.stata_do.do import StataDo
 
-BATCH_NAME_PATTERN = re.compile(r"^stata_batch__[0-9a-f]{32}\.do$")
+BATCH_NAME_PATTERN = re.compile(
+    r"^stata_batch__[0-9a-f]{32}__[A-Za-z0-9_]+\.do$"
+)
+UUID_BATCH_NAME_PATTERN = re.compile(r"^stata_batch__[0-9a-f]{32}\.do$")
 METACHARACTERS = "&^%!"
 
 
@@ -25,7 +30,7 @@ class TestGenerateBatchFileName:
     def test_matches_safe_pattern(self):
         name = StataDo._generate_batch_file_name()
 
-        assert BATCH_NAME_PATTERN.fullmatch(name)
+        assert UUID_BATCH_NAME_PATTERN.fullmatch(name)
 
     def test_unique_across_calls(self):
         names = {StataDo._generate_batch_file_name() for _ in range(64)}
@@ -37,6 +42,25 @@ class TestGenerateBatchFileName:
             name = StataDo._generate_batch_file_name()
 
             assert not any(char in name for char in METACHARACTERS)
+
+
+class TestCreateWindowsBatchFile:
+    def test_creates_complete_wrapper_with_safe_name(self, executor, malicious_dofile):
+        log_file = executor.log_file_path / "run.log"
+
+        batch_file = executor._create_windows_batch_file(
+            malicious_dofile.resolve(),
+            log_file,
+            True,
+        )
+
+        try:
+            assert BATCH_NAME_PATTERN.fullmatch(batch_file.name)
+            wrapper = batch_file.read_text(encoding="utf-8")
+            assert f'log using "{log_file}", replace' in wrapper
+            assert f'do "{malicious_dofile.resolve()}"' in wrapper
+        finally:
+            batch_file.unlink(missing_ok=True)
 
 
 class _FakeCompletedProcess:
@@ -93,6 +117,7 @@ class TestExecuteWindowsUsesSafeBatchName:
 
         def fake_run(cmd, **kwargs):
             captured["cmd"] = list(cmd)
+            captured["kwargs"] = kwargs
             return _FakeCompletedProcess()
 
         monkeypatch.setattr(
@@ -105,6 +130,8 @@ class TestExecuteWindowsUsesSafeBatchName:
         assert BATCH_NAME_PATTERN.fullmatch(Path(cmd[3]).name)
         assert not any(char in " ".join(cmd) for char in "&^%!")
         assert "calc.exe" not in " ".join(cmd)
+        assert captured["kwargs"]["shell"] is True
+        assert not Path(cmd[3]).exists()
 
 
 class TestExecuteWindowsWithMonitorsUsesSafeBatchName:
@@ -115,6 +142,7 @@ class TestExecuteWindowsWithMonitorsUsesSafeBatchName:
 
         def fake_popen(cmd, **kwargs):
             captured["cmd"] = list(cmd)
+            captured["kwargs"] = kwargs
             return _FakePopen()
 
         monkeypatch.setattr(
@@ -130,3 +158,50 @@ class TestExecuteWindowsWithMonitorsUsesSafeBatchName:
         assert BATCH_NAME_PATTERN.fullmatch(Path(cmd[3]).name)
         assert not any(char in " ".join(cmd) for char in "&^%!")
         assert "calc.exe" not in " ".join(cmd)
+        assert captured["kwargs"]["shell"] is True
+        assert not Path(cmd[3]).exists()
+
+
+class TestWindowsBatchCleanup:
+    def test_removes_batch_file_when_process_launch_fails(
+        self, monkeypatch, executor, malicious_dofile
+    ):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["batch_file"] = Path(cmd[3])
+            raise OSError("launch failed")
+
+        monkeypatch.setattr(
+            "stata_mcp.stata.stata_do.do.subprocess.run", fake_run
+        )
+
+        with pytest.raises(OSError, match="launch failed"):
+            executor.execute_dofile(malicious_dofile)
+
+        assert not captured["batch_file"].exists()
+
+    def test_removes_monitored_batch_file_after_timeout(
+        self, monkeypatch, executor, malicious_dofile
+    ):
+        captured = {}
+        process = Mock()
+        process.communicate.side_effect = subprocess.TimeoutExpired("stata", 1)
+        process.poll.side_effect = [None, 0]
+        process.wait.return_value = 0
+
+        def fake_popen(cmd, **kwargs):
+            captured["batch_file"] = Path(cmd[3])
+            return process
+
+        monkeypatch.setattr(
+            "stata_mcp.stata.stata_do.do.subprocess.Popen", fake_popen
+        )
+        executor.monitors = [SimpleNamespace(start=lambda proc: None, stop=lambda: None)]
+        executor.IS_MONITOR = True
+
+        with pytest.raises(RuntimeError, match="timed out after 1 second"):
+            executor.execute_dofile(malicious_dofile, timeout=1)
+
+        assert not captured["batch_file"].exists()
+        process.terminate.assert_called_once_with()

--- a/tests/stata/test_do_batch_filename.py
+++ b/tests/stata/test_do_batch_filename.py
@@ -1,0 +1,132 @@
+"""Tests that the Windows launcher batch filename is never derived from user input.
+
+The batch path is passed to a shell on Windows, so the do-file name (whose
+stem may legally contain characters that cmd.exe treats as syntax) must never
+be interpolated into the batch filename. Regression guard for the fix that
+replaced ``{dofile_path.stem}`` with a random uuid-based name in both
+``_execute_windows`` and ``_execute_windows_with_monitors``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from stata_mcp.stata.stata_do.do import StataDo
+
+BATCH_NAME_PATTERN = re.compile(r"^stata_batch__[0-9a-f]{32}\.do$")
+METACHARACTERS = "&^%!"
+
+
+class TestGenerateBatchFileName:
+    def test_matches_safe_pattern(self):
+        name = StataDo._generate_batch_file_name()
+
+        assert BATCH_NAME_PATTERN.fullmatch(name)
+
+    def test_unique_across_calls(self):
+        names = {StataDo._generate_batch_file_name() for _ in range(64)}
+
+        assert len(names) == 64
+
+    def test_contains_no_shell_metacharacters(self):
+        for _ in range(16):
+            name = StataDo._generate_batch_file_name()
+
+            assert not any(char in name for char in METACHARACTERS)
+
+
+class _FakeCompletedProcess:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+
+class _FakePopen:
+    returncode = 0
+
+    def poll(self):
+        return 0
+
+    def communicate(self, timeout=None):
+        return ("", "")
+
+    def terminate(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+@pytest.fixture
+def malicious_dofile(tmp_path: Path) -> Path:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    dofile = work_dir / "x&calc.exe&.do"
+    dofile.write_text("display 123\n")
+    return dofile
+
+
+@pytest.fixture
+def executor(tmp_path: Path) -> StataDo:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    return StataDo(
+        stata_cli=r"C:\Program Files\Stata18\StataMP-64.exe",
+        log_file_path=log_dir,
+        is_unix=False,
+        cwd=tmp_path,
+    )
+
+
+class TestExecuteWindowsUsesSafeBatchName:
+    def test_run_command_line_has_no_metacharacters(
+        self, monkeypatch, executor, malicious_dofile, tmp_path
+    ):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return _FakeCompletedProcess()
+
+        monkeypatch.setattr(
+            "stata_mcp.stata.stata_do.do.subprocess.run", fake_run
+        )
+
+        executor.execute_dofile(malicious_dofile)
+
+        cmd = captured["cmd"]
+        assert BATCH_NAME_PATTERN.fullmatch(Path(cmd[3]).name)
+        assert not any(char in " ".join(cmd) for char in "&^%!")
+        assert "calc.exe" not in " ".join(cmd)
+
+
+class TestExecuteWindowsWithMonitorsUsesSafeBatchName:
+    def test_popen_command_line_has_no_metacharacters(
+        self, monkeypatch, executor, malicious_dofile
+    ):
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return _FakePopen()
+
+        monkeypatch.setattr(
+            "stata_mcp.stata.stata_do.do.subprocess.Popen", fake_popen
+        )
+        executor.monitors = [SimpleNamespace(start=lambda proc: None,
+                                             stop=lambda: None)]
+        executor.IS_MONITOR = True
+
+        executor.execute_dofile(malicious_dofile)
+
+        cmd = captured["cmd"]
+        assert BATCH_NAME_PATTERN.fullmatch(Path(cmd[3]).name)
+        assert not any(char in " ".join(cmd) for char in "&^%!")
+        assert "calc.exe" not in " ".join(cmd)


### PR DESCRIPTION
The hazard is a combination of two things:

1. user-influenced bytes reaching the command line — the batch filename
   interpolated `dofile_path.stem`;
2. `shell=True`, which routes the whole command line through `cmd.exe`,
   where several characters that are legal in filenames are command syntax.

Removing **either** side breaks the chain. This PR removes side (1):

- `StataDo._generate_batch_file_name()` returns a random
  `stata_batch__{uuid4().hex}.do` name, used by both `_execute_windows`
  and `_execute_windows_with_monitors`. No user-controlled byte reaches
  the command line anymore. The batch file *content* (which references
  the do-file via `do "{dofile_path}"`) is unchanged, so behavior for
  normal do-files is byte-for-byte identical.
- Why prefer this over `shell=False`: dropping the shell changes the
  process-launch semantics (cmd.exe resolution of the executable — e.g.
  App Paths entries, or a `.bat`/`.cmd` shim as `STATA_CLI` — vs plain
  `CreateProcess`). That equivalence is hard to verify across user
  configurations without a Windows device, while the uuid change has a
  provably zero behavioral delta: the name is only used to create, write,
  pass and delete a throwaway temp file.

**Alternative:** setting `shell=False` on both Windows call sites is an
equally valid fix — it removes side (2): without a shell there is no
parser to interpret filename syntax. Happy to switch this PR to that
approach, or to split it into a follow-up, if you prefer; doing both
eventually gives defense in depth.