### PR TITLE
fix(deps): raise vulnerable dependency floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "mcp[cli]>=1.27.1,<2.0",
+    "mcp[cli]>=1.28.1,<2.0",
+    "cryptography>=50.0.0",
     "pandas>=3.0.0,<4.0.0",
     "pexpect>=4.9.0",
     "openpyxl>=3.1.5",
@@ -95,9 +96,11 @@ build = [
 ]
 
 agents = [
+    "mcp>=1.28.1,<2.0",
     "openai>=1.109.1",
     "openai-agents>=0.3.2",
     "openai-api-polling>=0.1.5",
+    "pyasn1>=0.6.4",
 ]
 
 ui = [


### PR DESCRIPTION
## Summary

- require `mcp>=1.28.1,<2.0` in core and standalone agents-group resolutions
- require `cryptography>=50.0.0` for the MCP/PyJWT runtime chain
- require `pyasn1>=0.6.4` for the optional agents dependency chain

## Security scope

This addresses the currently reported MCP, cryptography, and pyasn1 advisories without allowing MCP 2.x. The agents group repeats the MCP bound because `openai-agents` otherwise permits standalone resolution to MCP 2.x.

## Verification

- Python 3.11, 3.12, and 3.13 core/agents resolution and isolated imports
- MCP stdio initialize and `tools/list` (`stata_do`, `get_data_info`, `help`, `read_log`)
- `782 passed, 1 skipped`
- clean wheel and sdist build for 1.23.0
- `git diff --check`
