### PR TITLE
ci(security): set minimal workflow permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -5,8 +5,12 @@ on:
     paths:
       - '.github/labels.yml'
     branches:
-      - main  # 或者 master，取决于你的默认分支
+      - master
   workflow_dispatch:  # 允许手动触发
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   labels:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- restrict the lint workflow token to `contents: read`
- grant label sync only `contents: read` and `issues: write`
- correct the label-sync push trigger from `main` to the actual `master` branch

## Security impact

This removes implicit broad `GITHUB_TOKEN` permissions while preserving the exact capabilities each workflow needs. Neither workflow receives source-code write, release, package, or secrets permissions.

## Verification

- both workflow YAML files parse successfully
- upstream `EndBug/label-sync` documents `issues: write` for label maintenance
- exact two-file diff reviewed
- `git diff --check`
