### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like how you're building a safety-first framework for integrating Stata with AI agents, enabling robust empirical research. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Model-invocable skill grants side-effecting tools
   File: .claude/skills/rfc-impl-generator/SKILL.md
   What it means: Claude can auto-invoke this skill (disable-model-invocation is not set) and it pre-approves a side-effecting or exfiltration-capable tool (Bash / Write / Edit / WebFetch / NotebookEdit).

2. [HIGH] Agent wires MCP servers without input_guardrails
   File: src/stata_mcp/evaluate/agent_runner.py
   What it means: The agent imports tools from one or more MCP servers (mcp_servers=) but has no input_guardrails.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)